### PR TITLE
Qt6版本rocos

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,5 +69,5 @@ if(BUILD_DOC)
 endif()
 
 add_subdirectory(Client)
-# add_subdirectory(Core)
-# add_subdirectory(Controller)
+add_subdirectory(Core)
+add_subdirectory(Controller)

--- a/Client/Client.qrc
+++ b/Client/Client.qrc
@@ -92,6 +92,8 @@
         <file>src/qml/CustomDW/FloatingWindow.qml</file>
         <file>src/qml/CustomDW/Frame.qml</file>
         <file>src/qml/CustomDW/TitleBar.qml</file>
+        <file>src/qml/CustomDW/DockStyle.qml</file>
+        <file>src/qml/CustomDW/qmldir</file>
         <file>src/qml/Components/CButton.qml</file>
         <file>src/qml/Components/CColumn.qml</file>
         <file>src/qml/Components/CComboBox.qml</file>

--- a/Client/Client.qrc
+++ b/Client/Client.qrc
@@ -88,6 +88,7 @@
         <file>source/scissors2.png</file>
         <file>source/refresh.png</file>
         <file>src/qml/ZComboBox.qml</file>
+        <file>src/qml/ZSuggestComboBox.qml</file>
         <file>src/qml/CustomDW/DockWidget.qml</file>
         <file>src/qml/CustomDW/FloatingWindow.qml</file>
         <file>src/qml/CustomDW/Frame.qml</file>

--- a/Client/Client.qrc
+++ b/Client/Client.qrc
@@ -105,5 +105,6 @@
         <file>src/qml/Components/qmldir</file>
         <file>src/qml/Theme/qmldir</file>
         <file>src/qml/Theme/Theme.qml</file>
+        <file>src/qml/Components/NavView.qml</file>
     </qresource>
 </RCC>

--- a/Client/src/debugger.cpp
+++ b/Client/src/debugger.cpp
@@ -1,45 +1,33 @@
 #include "debugger.h"
 #include "globaldata.h"
-#include <thread>
-namespace {
-std::thread* blueDebuggerThread = nullptr;
-std::thread* yellowDebuggerThread = nullptr;
-}
+
 Debugger::Debugger(QObject *parent) : QObject(parent){
-//    QObject::connect(&receiverBlue,SIGNAL(readyRead()),this,SLOT(receiveBlue()),Qt::DirectConnection);
-    if(receiverBlue.bind(QHostAddress::AnyIPv4,ZSS::Athena::DEBUG_MSG_RECEIVE[0], QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)){
-        blueDebuggerThread = new std::thread([=,this] {receiveBlue();});
-        blueDebuggerThread->detach();
+    if (receiverBlue.bind(QHostAddress::AnyIPv4,
+                          ZSS::Athena::DEBUG_MSG_RECEIVE[0],
+                          QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)) {
+        QObject::connect(&receiverBlue, &QUdpSocket::readyRead, this, &Debugger::receiveBlue);
     }
-//    QObject::connect(&receiverYellow,SIGNAL(readyRead()),this,SLOT(receiveYellow()),Qt::DirectConnection);
-    if(receiverYellow.bind(QHostAddress::AnyIPv4,ZSS::Athena::DEBUG_MSG_RECEIVE[1], QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)){
-        yellowDebuggerThread = new std::thread([=,this] {receiveYellow();});
-        yellowDebuggerThread->detach();
+    if (receiverYellow.bind(QHostAddress::AnyIPv4,
+                            ZSS::Athena::DEBUG_MSG_RECEIVE[1],
+                            QUdpSocket::ShareAddress | QUdpSocket::ReuseAddressHint)) {
+        QObject::connect(&receiverYellow, &QUdpSocket::readyRead, this, &Debugger::receiveYellow);
     }
 }
 
 void Debugger::receiveBlue(){
     auto& datagram = GlobalData::instance()->debugBlueMessages;
-    while(true){
-        std::this_thread::sleep_for(std::chrono::microseconds(500));
-        while (receiverBlue.state() == QUdpSocket::BoundState && receiverBlue.hasPendingDatagrams()) {
-            GlobalData::instance()->debugMutex.lock();
-            datagram.resize(receiverBlue.pendingDatagramSize());
-            receiverBlue.readDatagram(datagram.data(),datagram.size());
-            GlobalData::instance()->debugMutex.unlock();
-        }
+    while (receiverBlue.state() == QUdpSocket::BoundState && receiverBlue.hasPendingDatagrams()) {
+        QMutexLocker lock(&GlobalData::instance()->debugMutex);
+        datagram.resize(receiverBlue.pendingDatagramSize());
+        receiverBlue.readDatagram(datagram.data(), datagram.size());
     }
 }
 
 void Debugger::receiveYellow(){
     auto& datagram = GlobalData::instance()->debugYellowMessages;
-    while(true){
-        std::this_thread::sleep_for(std::chrono::microseconds(500));
-        while (receiverYellow.state() == QUdpSocket::BoundState && receiverYellow.hasPendingDatagrams()) {
-            GlobalData::instance()->debugMutex.lock();
-            datagram.resize(receiverYellow.pendingDatagramSize());
-            receiverYellow.readDatagram(datagram.data(),datagram.size());
-            GlobalData::instance()->debugMutex.unlock();
-        }
+    while (receiverYellow.state() == QUdpSocket::BoundState && receiverYellow.hasPendingDatagrams()) {
+        QMutexLocker lock(&GlobalData::instance()->debugMutex);
+        datagram.resize(receiverYellow.pendingDatagramSize());
+        receiverYellow.readDatagram(datagram.data(), datagram.size());
     }
 }

--- a/Client/src/field.cpp
+++ b/Client/src/field.cpp
@@ -215,7 +215,7 @@ int Field::_global_height = 0;
 Field::Field(QQuickItem* parent)
     : QQuickPaintedItem(parent)
     , _root("FieldRoot")
-    , s_need_draw("field_draw_trigger", [this](const zos::Data&) { draw(); }) {
+    , s_need_draw("field_draw_trigger", [this](const zos::Data&) { sendSignal(); }) {
     int defaultHeight = 960;
     int defaultWidth = 1280;
     ZSS::ZParamManager::_()->loadParam(defaultHeight, "canvas/height", 960);
@@ -236,6 +236,7 @@ Field::Field(QQuickItem* parent)
     VisionModule::instance()->p_draw_signal.link(&_layer_vision->s_draw_data);
     VisionModule::instance()->p_draw_signal.link(&s_need_draw);
 
+    connect(this, &Field::needDraw, this, &Field::draw, Qt::QueuedConnection);
     connect(GlobalSettings::instance(), &CGlobalSettings::needRepaint, this, &Field::draw);
 
     // setImplicitWidth/Height may trigger geometryChange -> resize.

--- a/Client/src/field.cpp
+++ b/Client/src/field.cpp
@@ -111,7 +111,9 @@ void paintRobotShape(QPainter& painter,
 
     if (drawId) {
         QFont font;
-        font.setPixelSize(std::max(10, int(scale * 0.9)));
+        const int idPixelSize = std::max(20, int(scale * carDiameter * 0.9));
+        font.setPixelSize(idPixelSize);
+        // font.setBold(true);
         painter.setFont(font);
         painter.setBrush(Qt::NoBrush);
         painter.setPen(QPen(textColor, std::max(1.0, scale * 0.4)));
@@ -379,15 +381,11 @@ void Field::draw() {
     }
 
     _layer_field_line->draw();
-    if (_type != 1) {
+    const bool originView = (_type == 1);
+    if (!originView) {
         _layer_vision->draw();
-    } else {
-        std::scoped_lock<std::shared_mutex> lock(_layer_vision->_mutex);
-        if (_layer_vision->_image != nullptr) {
-            _layer_vision->_image->fill(Qt::transparent);
-        }
+        _root.draw();
     }
-    _root.draw();
 
     const QTransform tf = currentTransform(_tf);
 
@@ -395,7 +393,13 @@ void Field::draw() {
         std::scoped_lock<std::shared_mutex> lock(_mutex);
         _pm->fill(Color::_()->BACKGROUND);
 
-        {
+        if (originView) {
+            // Origin view paints robots/balls directly; skip VisionLayer compositing to avoid text-size flicker.
+            std::shared_lock<std::shared_mutex> fieldLineLock(_layer_field_line->_mutex);
+            if (_layer_field_line->_image != nullptr) {
+                _painter.drawImage(0, 0, *_layer_field_line->_image);
+            }
+        } else {
             std::shared_lock<std::shared_mutex> rootLock(_root._mutex);
             if (_root._image != nullptr) {
                 _painter.drawImage(0, 0, *_root._image);

--- a/Client/src/field.cpp
+++ b/Client/src/field.cpp
@@ -1,118 +1,485 @@
 #include "field.h"
-#include <QtGlobal>
-#include <QtDebug>
-#include <QtMath>
-#include "simulator.h"
+
 #include "fieldlayers.h"
-#include "interaction.h"
+#include "globaldata.h"
+#include "globalsettings.h"
 #include "parammanager.h"
-#include "visionmodule.h"
+#include "simulator.h"
 #include "themecolor.h"
+#include "zss_debug.pb.h"
 
-Field::Field(QQuickItem *parent)
-    : QQuickPaintedItem(parent),
-      s_need_draw("field_draw_signal",[this](const zos::Data&){this->draw();}){
-    _timer.start();
-    int canvasWidth,canvasHeight;
-    ZSS::ZParamManager::_()->loadParam(canvasWidth,"GUI/canvasWidth",300);
-    ZSS::ZParamManager::_()->loadParam(canvasHeight,"GUI/canvasHeight",200);
-    setImplicitWidth(canvasWidth);
-    setImplicitHeight(canvasHeight);
-    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton | Qt::MiddleButton);
-    auto* fieldLineLayer = new FieldLineLayer(&_tf);
-    auto* visionLayer = new VisionLayer(&_tf);
-    auto* debugBlueLayer = new DebugLayer(&_tf,PARAM::BLUE);
-    auto* debugYellowLayer = new DebugLayer(&_tf,PARAM::YELLOW);
+#include <QFont>
+#include <QtMath>
 
-    CInteraction::_()->_draw_signal.link(&fieldLineLayer->s_need_draw);
-    CInteraction::_()->_draw_signal.link(&visionLayer->s_need_draw);
-    CInteraction::_()->_draw_signal.link(&debugBlueLayer->s_need_draw);
-    CInteraction::_()->_draw_signal.link(&debugYellowLayer->s_need_draw);
+#include <algorithm>
+#include <cmath>
 
-    VisionModule::instance()->p_draw_signal.link(&visionLayer->s_draw_data);
+namespace {
+constexpr float kMinSelectionLength = 500.0F; // mm
+constexpr qreal kZoomStep = 0.05;
+constexpr qreal kZoomMin = 0.1;
+constexpr int kBallSpeedRatio = 3;
 
-    _root.addChild(fieldLineLayer);
-    _root.addChild(visionLayer);
-    _root.addChild(debugBlueLayer);
-    _root.addChild(debugYellowLayer);
+using ZSS::Protocol::Debug_Msgs;
 
-    _root.p_draw_done.link(&this->s_need_draw);
-    CInteraction::_()->_extra_draw_signal.link(&this->s_need_draw);
-
-    connect(this,SIGNAL(needDraw()),this, SLOT(updateArea()));
+QTransform currentTransform(FieldTransform& tf) {
+    std::shared_lock<std::shared_mutex> lock(tf.mutex);
+    return tf._;
 }
-void Field::resize(int width,int height,bool update){
-    if (width <= 0 || height <= 0) return;
-    if (width == _area.width() && height == _area.height()) return;
-    if (update){
-        ZSS::ZParamManager::_()->changeParam("GUI/canvasWidth",width);
-        ZSS::ZParamManager::_()->changeParam("GUI/canvasHeight",height);
+
+QPointF mapFieldPoint(const QTransform& tf, const QPointF& fieldPoint) {
+    return tf.map(fieldPoint);
+}
+
+QRectF mapFieldRect(const QTransform& tf, double minX, double maxX, double minY, double maxY) {
+    const QPointF p1 = tf.map(QPointF(minX, minY));
+    const QPointF p2 = tf.map(QPointF(maxX, maxY));
+    return QRectF(p1, p2).normalized();
+}
+
+QPointF toFieldPoint(FieldTransform& tf, const QPointF& screenPoint) {
+    std::shared_lock<std::shared_mutex> lock(tf.mutex);
+    bool ok = false;
+    const QTransform inverse = tf._.inverted(&ok);
+    if (!ok) {
+        return QPointF(0.0, 0.0);
     }
+    return inverse.map(screenPoint);
+}
+
+template <typename T>
+T clampValue(T value, T minValue, T maxValue) {
+    return std::max(minValue, std::min(value, maxValue));
+}
+
+const Msg::Robot* findRobotById(const OriginMessage& vision, int team, int id) {
+    if (team < PARAM::BLUE || team > PARAM::YELLOW || id < 0 || id >= PARAM::ROBOTMAXID) {
+        return nullptr;
+    }
+    const int idx = vision.robotIndex[team][id];
+    if (idx < 0 || idx >= vision.robotSize[team]) {
+        return nullptr;
+    }
+    return &vision.robot[team][idx];
+}
+
+void paintRobotShape(QPainter& painter,
+                     const QTransform& tf,
+                     const QColor& color,
+                     quint8 id,
+                     qreal x,
+                     qreal y,
+                     qreal radian,
+                     bool drawId,
+                     const QColor& textColor,
+                     bool selectedCircle) {
+    const qreal carDiameter = FP::_()->s_carDiameter;
+    const qreal carFaceWidth = FP::_()->s_carFaceWidth;
+    const qreal radius = carDiameter / 2.0;
+    const qreal chordAngle = qRadiansToDegrees(qAcos(carFaceWidth / carDiameter));
+    const qreal scale = std::abs(tf.m11());
+
+    painter.setBrush(QBrush(color));
+    painter.setPen(QPen(Color::_()->ROBOT_DIR, std::max(1.0, scale * 0.3), Qt::DotLine));
+
+    const QPointF center = tf.map(QPointF(x, y));
+    const QPointF dir = tf.map(QPointF(x, y) + QPointF(140 * qSin(-radian + M_PI_2), 140 * qCos(-radian + M_PI_2)));
+    painter.drawLine(center, dir);
+
+    painter.setPen(Qt::NoPen);
+    painter.drawChord(tf.mapRect(QRectF(x - radius, y - radius, 2 * radius, 2 * radius)),
+                     int((-90.0 + chordAngle + 180.0 / M_PI * radian) * 16),
+                     int((-180.0 - 2 * chordAngle) * 16));
+
+    if (selectedCircle) {
+        painter.setBrush(Qt::NoBrush);
+        painter.setPen(QPen(QColor(27, 129, 62), std::max(1.0, scale * 0.5)));
+        painter.drawChord(tf.mapRect(QRectF(x - radius, y - radius, 2 * radius, 2 * radius)),
+                         int((-90.0 + chordAngle + 180.0 / M_PI * radian) * 16),
+                         int((-180.0 - 2 * chordAngle) * 16));
+    }
+
+    if (drawId) {
+        QFont font;
+        font.setPixelSize(std::max(10, int(scale * 0.9)));
+        painter.setFont(font);
+        painter.setBrush(Qt::NoBrush);
+        painter.setPen(QPen(textColor, std::max(1.0, scale * 0.4)));
+        painter.drawText(tf.map(QPointF(x - FP::_()->s_number * 0.8, y + FP::_()->s_carDiameter * 0.35)),
+                        QString::number(id, 16).toUpper());
+    }
+}
+
+void paintBallShape(QPainter& painter, const QTransform& tf, const QColor& color, qreal x, qreal y, qreal diameter) {
+    painter.setBrush(QBrush(color));
+    painter.setPen(Qt::NoPen);
+    painter.drawEllipse(tf.mapRect(QRectF(x - diameter / 2.0, y - diameter / 2.0, diameter, diameter)));
+}
+
+void paintOriginVision(QPainter& painter, const QTransform& tf) {
+    for (int cam = 0; cam < PARAM::CAMERA; ++cam) {
+        if (!GlobalData::instance()->cameraControl[cam]) {
+            continue;
+        }
+        const OriginMessage& msg = GlobalData::instance()->camera[cam][0];
+
+        for (int team = PARAM::BLUE; team <= PARAM::YELLOW; ++team) {
+            for (int i = 0; i < msg.robotSize[team]; ++i) {
+                const auto& robot = msg.robot[team][i];
+                paintRobotShape(painter,
+                                tf,
+                                Color::_()->ROBOT[team],
+                                robot.id,
+                                robot.pos.x(),
+                                robot.pos.y(),
+                                robot.angle,
+                                true,
+                                Qt::white,
+                                false);
+            }
+        }
+
+        for (int i = 0; i < msg.ballSize; ++i) {
+            const auto& ball = msg.ball[i];
+            paintBallShape(painter, tf, Color::_()->BALL, ball.pos.x(), ball.pos.y(), FP::_()->s_ballDiameter);
+        }
+    }
+}
+
+void paintDebugMessages(QPainter& painter, const QTransform& tf, int team) {
+    Debug_Msgs msgs;
     {
-        std::scoped_lock<std::shared_mutex> lock(_tf.mutex);
-        _tf.update(width,height);
+        QMutexLocker lock(&GlobalData::instance()->debugMutex);
+        if (team == PARAM::BLUE) {
+            msgs.ParseFromArray(GlobalData::instance()->debugBlueMessages.data(),
+                                GlobalData::instance()->debugBlueMessages.size());
+        } else {
+            msgs.ParseFromArray(GlobalData::instance()->debugYellowMessages.data(),
+                                GlobalData::instance()->debugYellowMessages.size());
+        }
     }
-    {
-        std::scoped_lock lock(_mutex);
-        if(_painter.isActive())
-            _painter.end();
-        delete _pm;
-        _pm = new QPixmap(QSize(width, height));
-        _pm->fill(Color::_()->BACKGROUND);
-        _area = QRect(0, 0, width, height);
-        _painter.begin(_pm);
-        _painter.setRenderHint(QPainter::Antialiasing, true);
-        _painter.setRenderHint(QPainter::TextAntialiasing, true);
+
+    painter.setBrush(QBrush(Color::_()->DEBUG_BRUSH_COLOR));
+    QFont font("Ubuntu Mono", std::max(10, int(std::abs(tf.m11()) * 0.8)), QFont::Normal);
+    painter.setFont(font);
+
+    for (int i = 0; i < msgs.msgs_size(); ++i) {
+        const auto& msg = msgs.msgs(i);
+        const int colorIdx = clampValue(int(msg.color()), 0, 9);
+        painter.setPen(QPen(Color::_()->DEBUG_MSG[colorIdx], std::max(1.0, std::abs(tf.m11()) * 0.12)));
+
+        switch (msg.type()) {
+        case ZSS::Protocol::Debug_Msg_Debug_Type_ARC: {
+            const double x1 = msg.arc().rect().point1().x();
+            const double y1 = msg.arc().rect().point1().y();
+            const double x2 = msg.arc().rect().point2().x();
+            const double y2 = msg.arc().rect().point2().y();
+            const QRectF rect = tf.mapRect(QRectF(std::min(x1, x2), std::min(y1, y2), std::abs(x2 - x1), std::abs(y2 - y1)));
+            painter.drawArc(rect, int(msg.arc().start() * -16), int(msg.arc().span() * -16));
+            break;
+        }
+        case ZSS::Protocol::Debug_Msg_Debug_Type_LINE:
+            painter.drawLine(tf.map(QPointF(msg.line().start().x(), msg.line().start().y())),
+                             tf.map(QPointF(msg.line().end().x(), msg.line().end().y())));
+            break;
+        case ZSS::Protocol::Debug_Msg_Debug_Type_POINTS: {
+            QVector<QLineF> lines;
+            const double d = FP::_()->s_debugPoint;
+            for (int k = 0; k < msg.points().point_size(); ++k) {
+                const auto& p = msg.points().point(k);
+                lines.push_back(tf.map(QLineF(p.x() + d, p.y() + d, p.x() - d, p.y() - d)));
+                lines.push_back(tf.map(QLineF(p.x() - d, p.y() + d, p.x() + d, p.y() - d)));
+            }
+            painter.drawLines(lines);
+            break;
+        }
+        case ZSS::Protocol::Debug_Msg_Debug_Type_TEXT:
+            font.setPointSizeF(std::max(8.0, std::abs(tf.m11()) * msg.text().size() * 0.01));
+            font.setWeight(static_cast<QFont::Weight>(msg.text().weight()));
+            painter.setFont(font);
+            painter.drawText(tf.map(QPointF(msg.text().pos().x(), msg.text().pos().y())),
+                             QString::fromStdString(msg.text().text()));
+            break;
+        default:
+            break;
+        }
     }
-    _root.resize(width,height);
-    sendSignal();
+}
+} // namespace
+
+std::shared_mutex Field::_global_mutex;
+QTransform Field::_global_tf;
+int Field::_global_width = 0;
+int Field::_global_height = 0;
+
+Field::Field(QQuickItem* parent)
+    : QQuickPaintedItem(parent)
+    , _root("FieldRoot")
+    , s_need_draw("field_draw_trigger", [this](const zos::Data&) { draw(); }) {
+    int defaultHeight = 960;
+    int defaultWidth = 1280;
+    ZSS::ZParamManager::_()->loadParam(defaultHeight, "canvas/height", 960);
+    ZSS::ZParamManager::_()->loadParam(defaultWidth, "canvas/width", 1280);
+
+    setFillColor(Color::_()->BACKGROUND);
+    setAcceptedMouseButtons(Qt::LeftButton | Qt::RightButton | Qt::MiddleButton);
+
+    _selected_ids.fill(-1);
+    _buttons = Qt::NoButton;
+    _mouse_modifiers = Qt::NoModifier;
+
+    _layer_field_line = new FieldLineLayer(&_tf);
+    _layer_vision = new VisionLayer(&_tf);
+    _root.addChild(_layer_field_line);
+    _root.addChild(_layer_vision);
+
+    VisionModule::instance()->p_draw_signal.link(&_layer_vision->s_draw_data);
+    VisionModule::instance()->p_draw_signal.link(&s_need_draw);
+
+    connect(GlobalSettings::instance(), &CGlobalSettings::needRepaint, this, &Field::draw);
+
+    // setImplicitWidth/Height may trigger geometryChange -> resize.
+    // Keep these calls after layer initialization to avoid null dereference.
+    setImplicitWidth(defaultWidth);
+    setImplicitHeight(defaultHeight);
+
+    GlobalSettings::instance()->resetArea();
+    resize(defaultWidth, defaultHeight, false);
+}
+
+Field::~Field() {
+    std::scoped_lock<std::shared_mutex> lock(_mutex);
+    if (_painter.isActive()) {
+        _painter.end();
+    }
+    delete _pm;
+    _pm = nullptr;
 }
 
 void Field::paint(QPainter* painter) {
-    if(_mutex.try_lock()){
-        if(_pm != nullptr){
-            painter->drawPixmap(_area, *_pm);
-        }
-        _mutex.unlock();
+    std::shared_lock<std::shared_mutex> lock(_mutex);
+    if (_pm == nullptr) {
+        return;
     }
+    painter->drawPixmap(_area, *_pm);
 }
-void Field::updateArea(){
-    this->update(_area);
-}
-void Field::draw(){
-    if(_timer.elapsed()>1000.0/PARAM::GUI_DRAW_RATE || !_first){
-        _timer.restart();
-        _first = true;
-        std::scoped_lock lock(_mutex);
-        _pm->fill(Color::_()->BACKGROUND);
-        {
-            std::scoped_lock lock(_root._mutex);
-            _painter.drawImage(0,0,*(_root.get()));
-        }
-        emit needDraw();
-    }
-}
-void Field::mousePressEvent(QMouseEvent *e) {
-    _check_press_robot.res = false;
-    {
-        std::shared_lock lock(_tf.mutex);
-        _start = _tf._.inverted().map(e->pos());
-        _old_tf = _tf._;
-    }
-    _end = _start;
-    _buttons = e->buttons();
-    _mouse_modifiers = e->modifiers();
 
-    _check_press_robot = VisionModule::_()->checkRobot(_start.x(),_start.y());
-    qDebug() << "press event : " << _check_press_robot.res << _check_press_robot.team << _check_press_robot.id;
-    mouseMoveEvent(e);
-}
-void Field::mouseMoveEvent(QMouseEvent *e) {
-    {
-        std::shared_lock lock(_tf.mutex);
-        _end = _tf._.inverted().map(e->pos());
+void Field::geometryChange(const QRectF& newGeometry, const QRectF& oldGeometry) {
+    QQuickPaintedItem::geometryChange(newGeometry, oldGeometry);
+    if (_layer_field_line == nullptr || _layer_vision == nullptr) {
+        return;
     }
-    switch(e->buttons()) {
+    const int w = int(newGeometry.width());
+    const int h = int(newGeometry.height());
+    if (w > 0 && h > 0) {
+        resize(w, h, true);
+    }
+}
+
+void Field::resize(int width, int height, bool needUpdate) {
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+
+    setSize(width, height);
+    _area = QRect(0, 0, width, height);
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_mutex);
+        if (_pm == nullptr || _pm->size() != QSize(width, height)) {
+            if (_painter.isActive()) {
+                _painter.end();
+            }
+            delete _pm;
+            _pm = new QPixmap(width, height);
+            _pm->fill(Color::_()->BACKGROUND);
+            _painter.begin(_pm);
+            _painter.setRenderHint(QPainter::Antialiasing, true);
+            _painter.setRenderHint(QPainter::TextAntialiasing, true);
+        }
+    }
+
+    _root.resize(width, height);
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_tf.mutex);
+        _tf.update(width, height);
+    }
+    _tf.limit(width, height);
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_global_mutex);
+        _global_tf = currentTransform(_tf);
+        _global_width = width;
+        _global_height = height;
+    }
+
+    if (_layer_field_line != nullptr) {
+        _layer_field_line->draw();
+    }
+
+    if (needUpdate) {
+        draw();
+    }
+}
+
+void Field::setSize(int width, int height) {
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+    ZSS::ZParamManager::_()->changeParam("canvas/height", height);
+    ZSS::ZParamManager::_()->changeParam("canvas/width", width);
+}
+
+float Field::fieldXFromCoordinate(int x) {
+    std::shared_lock<std::shared_mutex> lock(_global_mutex);
+    bool ok = false;
+    const QTransform inv = _global_tf.inverted(&ok);
+    if (!ok) {
+        return 0.0F;
+    }
+    return float(inv.map(QPointF(x, 0.0)).x());
+}
+
+float Field::fieldYFromCoordinate(int y) {
+    std::shared_lock<std::shared_mutex> lock(_global_mutex);
+    bool ok = false;
+    const QTransform inv = _global_tf.inverted(&ok);
+    if (!ok) {
+        return 0.0F;
+    }
+    return float(inv.map(QPointF(0.0, y)).y());
+}
+
+void Field::updateArea() {
+    update(_area);
+}
+
+void Field::sendSignal() {
+    emit needDraw();
+}
+
+void Field::draw() {
+    if (_pm == nullptr || _area.width() <= 0 || _area.height() <= 0) {
+        return;
+    }
+    if (!_draw && _type > 0) {
+        return;
+    }
+
+    _layer_field_line->draw();
+    if (_type != 1) {
+        _layer_vision->draw();
+    } else {
+        std::scoped_lock<std::shared_mutex> lock(_layer_vision->_mutex);
+        if (_layer_vision->_image != nullptr) {
+            _layer_vision->_image->fill(Qt::transparent);
+        }
+    }
+    _root.draw();
+
+    const QTransform tf = currentTransform(_tf);
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_mutex);
+        _pm->fill(Color::_()->BACKGROUND);
+
+        {
+            std::shared_lock<std::shared_mutex> rootLock(_root._mutex);
+            if (_root._image != nullptr) {
+                _painter.drawImage(0, 0, *_root._image);
+            }
+        }
+
+        if (_type == 1) {
+            paintOriginVision(_painter, tf);
+        } else if (_type == 2) {
+            paintDebugMessages(_painter, tf, PARAM::BLUE);
+        } else if (_type == 3) {
+            paintDebugMessages(_painter, tf, PARAM::YELLOW);
+        }
+
+        if (_select_robots) {
+            const OriginMessage& vision = GlobalData::instance()->processRobot[0];
+            for (int i = 0; i < _selected_count; ++i) {
+                const Msg::Robot* robot = findRobotById(vision, _selected_team, _selected_ids[i]);
+                if (robot == nullptr) {
+                    continue;
+                }
+                paintRobotShape(_painter,
+                                tf,
+                                QColor(0, 0, 0, 0),
+                                robot->id,
+                                robot->pos.x(),
+                                robot->pos.y(),
+                                robot->angle,
+                                false,
+                                Qt::white,
+                                true);
+            }
+        }
+
+        _painter.setBrush(QBrush(QColor(255, 255, 255, 20)));
+        _painter.setPen(Qt::NoPen);
+        _painter.drawRect(mapFieldRect(tf,
+                                       GlobalSettings::instance()->minimumX,
+                                       GlobalSettings::instance()->maximumX,
+                                       GlobalSettings::instance()->minimumY,
+                                       GlobalSettings::instance()->maximumY));
+
+        const QColor selectColor = _selected_team == PARAM::BLUE ? QColor(0, 137, 167, 50) : QColor(221, 210, 59, 50);
+        _painter.setBrush(QBrush(selectColor));
+        _painter.setPen(QPen(selectColor, 2));
+        _painter.drawRect(mapFieldRect(tf,
+                                       GlobalSettings::instance()->selectCarMinX,
+                                       GlobalSettings::instance()->selectCarMaxX,
+                                       GlobalSettings::instance()->selectCarMinY,
+                                       GlobalSettings::instance()->selectCarMaxY));
+
+        if (_buttons == Qt::RightButton) {
+            _painter.setBrush(Qt::NoBrush);
+            _painter.setPen(QPen(Qt::white, std::max(1.0, std::abs(tf.m11()) * 0.2), Qt::DashLine));
+            _painter.drawLine(mapFieldPoint(tf, _start), mapFieldPoint(tf, _end));
+            _painter.drawText(mapFieldPoint(tf, _end), QString::number(_display_data, 'f', 2));
+        }
+
+        bool ctrlC = false;
+        {
+            QMutexLocker lock(&GlobalData::instance()->ctrlCMutex);
+            ctrlC = GlobalData::instance()->ctrlC;
+        }
+        if (ctrlC) {
+            QFont font("Ubuntu Mono", std::max(24, _area.height() / 8), QFont::Bold);
+            _painter.setFont(font);
+            _painter.setPen(QPen(Qt::white));
+            _painter.drawText(QPointF(20, font.pixelSize() + 20), "CTRL_C");
+        }
+    }
+
+    updateArea();
+}
+
+void Field::mousePressEvent(QMouseEvent* event) {
+    _buttons = event->button();
+    _mouse_modifiers = event->modifiers();
+    _start_screen = event->position();
+    _end_screen = _start_screen;
+    _start = _end = toFieldPoint(_tf, _start_screen);
+    _event_stage = 0;
+
+    _check_press_robot = VisionModule::instance()->checkRobot(_start.x(), _start.y());
+    _pressed_robot = _check_press_robot.res;
+    _origin_robot = GlobalData::instance()->processRobot[0];
+    _old_tf = currentTransform(_tf);
+
+    if (_pressed_robot && !_select_robots) {
+        _selected_team = _check_press_robot.team;
+        _selected_count = 1;
+        _selected_ids.fill(-1);
+        _selected_ids[0] = int(_check_press_robot.id);
+    }
+
+    switch (_buttons) {
     case Qt::LeftButton:
         e_left();
         break;
@@ -125,53 +492,182 @@ void Field::mouseMoveEvent(QMouseEvent *e) {
     default:
         break;
     }
-    sendSignal();
-}
-void Field::mouseReleaseEvent(QMouseEvent *e) {
-    {
-        std::shared_lock lock(_tf.mutex);
-        _end = _tf._.inverted().map(e->pos());
-    }
-    mouseMoveEvent(e);
-    if(!_check_press_robot.res && _buttons==Qt::RightButton){
-        e_right_r();
-    }
-    sendSignal();
+
+    draw();
 }
 
-void Field::e_left() {
-    switch(_mouse_modifiers) {
-    case Qt::NoModifier :
-        if(_check_press_robot.res) {
-            Simulator::instance()->setRobot(_end.x()/1000.0,_end.y()/1000.0,_check_press_robot.id,_check_press_robot.team,_check_press_robot.orientation/M_PI*180);
-        } else {
-            Simulator::instance()->setBall(_end.x()/1000.0,_end.y()/1000.0);
-        }
+void Field::mouseMoveEvent(QMouseEvent* event) {
+    if (_buttons == Qt::NoButton) {
+        return;
+    }
+    _mouse_modifiers = event->modifiers();
+    _end_screen = event->position();
+    _end = toFieldPoint(_tf, _end_screen);
+    _event_stage = 1;
+
+    switch (_buttons) {
+    case Qt::LeftButton:
+        e_left();
+        break;
+    case Qt::RightButton:
+        e_right();
+        break;
+    case Qt::MiddleButton:
+        e_middle();
         break;
     default:
         break;
     }
+
+    draw();
 }
+
+void Field::mouseReleaseEvent(QMouseEvent* event) {
+    if (_buttons == Qt::NoButton) {
+        return;
+    }
+
+    _mouse_modifiers = event->modifiers();
+    _end_screen = event->position();
+    _end = toFieldPoint(_tf, _end_screen);
+    _event_stage = 2;
+
+    switch (_buttons) {
+    case Qt::LeftButton:
+        e_left();
+        break;
+    case Qt::RightButton:
+        e_right();
+        e_right_r();
+        break;
+    case Qt::MiddleButton:
+        e_middle();
+        break;
+    default:
+        break;
+    }
+
+    _buttons = Qt::NoButton;
+    _mouse_modifiers = Qt::NoModifier;
+    _pressed_robot = false;
+
+    draw();
+}
+
+void Field::e_left() {
+    if (_mouse_modifiers == Qt::ControlModifier || _mouse_modifiers == Qt::AltModifier) {
+        _selected_team = _mouse_modifiers == Qt::ControlModifier ? PARAM::BLUE : PARAM::YELLOW;
+
+        const double minX = std::min(_start.x(), _end.x());
+        const double maxX = std::max(_start.x(), _end.x());
+        const double minY = std::min(_start.y(), _end.y());
+        const double maxY = std::max(_start.y(), _end.y());
+
+        if (maxX - minX < kMinSelectionLength || maxY - minY < kMinSelectionLength) {
+            GlobalSettings::instance()->resetSelectCarArea();
+            if (_event_stage == 2) {
+                _selected_count = 0;
+                _selected_ids.fill(-1);
+                _select_robots = false;
+            }
+            return;
+        }
+
+        GlobalSettings::instance()->setSelectCarArea(minX, maxX, minY, maxY);
+
+        if (_event_stage == 2) {
+            _selected_count = 0;
+            _selected_ids.fill(-1);
+            const auto& vision = GlobalData::instance()->processRobot[0];
+            for (int i = 0; i < vision.robotSize[_selected_team]; ++i) {
+                const auto& robot = vision.robot[_selected_team][i];
+                if (robot.pos.x() > minX && robot.pos.x() < maxX && robot.pos.y() > minY && robot.pos.y() < maxY) {
+                    if (_selected_count < PARAM::ROBOTNUM) {
+                        _selected_ids[_selected_count++] = int(robot.id);
+                    }
+                }
+            }
+            _select_robots = _selected_count > 0;
+            GlobalSettings::instance()->resetSelectCarArea();
+        }
+        return;
+    }
+
+    if (!_pressed_robot) {
+        Simulator::instance()->setBall(_end.x() / 1000.0, _end.y() / 1000.0);
+        return;
+    }
+
+    const QPointF delta = _end - _start;
+
+    if (!_select_robots) {
+        _selected_team = _check_press_robot.team;
+        _selected_count = 1;
+        _selected_ids.fill(-1);
+        _selected_ids[0] = int(_check_press_robot.id);
+    }
+
+    const OriginMessage& current = GlobalData::instance()->processRobot[0];
+    for (int i = 0; i < _selected_count; ++i) {
+        const int id = _selected_ids[i];
+        const Msg::Robot* originRobot = findRobotById(_origin_robot, _selected_team, id);
+        const Msg::Robot* currentRobot = findRobotById(current, _selected_team, id);
+        if (currentRobot == nullptr) {
+            continue;
+        }
+
+        const QPointF base = originRobot == nullptr
+            ? QPointF(currentRobot->pos.x(), currentRobot->pos.y())
+            : QPointF(originRobot->pos.x(), originRobot->pos.y());
+
+        const double dir = currentRobot->angle * 180.0 / M_PI;
+        Simulator::instance()->setRobot((base.x() + delta.x()) / 1000.0,
+                                        (base.y() + delta.y()) / 1000.0,
+                                        id,
+                                        _selected_team == PARAM::YELLOW,
+                                        dir);
+    }
+}
+
 void Field::e_right() {
-    auto&& _r = _check_press_robot;
-    QLineF line(_start, _end);
-    if(_check_press_robot.res) {
-        Simulator::instance()->setRobot(_r.x/1000.0,_r.y/1000.0,_r.id,_r.team,-line.angle());
+    const QLineF line(_start, _end);
+    if (_pressed_robot) {
+        _display_data = -line.angle();
+        if (_display_data < -180.0) {
+            _display_data += 360.0;
+        }
+
+        const OriginMessage& current = GlobalData::instance()->processRobot[0];
+        for (int i = 0; i < _selected_count; ++i) {
+            const int id = _selected_ids[i];
+            const Msg::Robot* robot = findRobotById(current, _selected_team, id);
+            if (robot == nullptr) {
+                continue;
+            }
+            Simulator::instance()->setRobot(robot->pos.x() / 1000.0,
+                                            robot->pos.y() / 1000.0,
+                                            id,
+                                            _selected_team == PARAM::YELLOW,
+                                            _display_data);
+        }
     } else {
-        Simulator::instance()->setBall(_start.x()/1000.0,_start.y()/1000.0);
+        _display_data = kBallSpeedRatio * line.length() / 1000.0;
     }
 }
+
 void Field::e_right_r() {
-    auto&& _r = _check_press_robot;
-    QLineF line(_start, _end);
-    if(_check_press_robot.res) {
-        Simulator::instance()->setRobot(_r.x/1000.0,_r.y/1000.0,_r.id,_r.team,-line.angle());
-    } else {
-        Simulator::instance()->setBall(_start.x()/1000.0,_start.y()/1000.0,line.dx()/1000.0,line.dy()/1000.0);
+    if (_pressed_robot) {
+        return;
     }
+    const QLineF line(_start, _end);
+    Simulator::instance()->setBall(_start.x() / 1000.0,
+                                   _start.y() / 1000.0,
+                                   kBallSpeedRatio * line.dx() / 1000.0,
+                                   kBallSpeedRatio * line.dy() / 1000.0);
 }
+
 void Field::e_middle() {
-    switch(_mouse_modifiers) {
+    switch (_mouse_modifiers) {
     case Qt::NoModifier:
         e_middle_none();
         break;
@@ -185,51 +681,101 @@ void Field::e_middle() {
         break;
     }
 }
+
 void Field::e_middle_none() {
-    auto d = _end-_start;
+    if (_event_stage == 0) {
+        _old_tf = currentTransform(_tf);
+        return;
+    }
+
+    const QPointF delta = _end_screen - _start_screen;
+    const double scale = std::abs(_old_tf.m11());
+    QTransform next(scale, 0, 0, -scale, _old_tf.dx() + delta.x(), _old_tf.dy() + delta.y());
+
     {
         std::scoped_lock<std::shared_mutex> lock(_tf.mutex);
-        _tf._ = _old_tf.translate(d.x(),d.y());
+        _tf._ = next;
     }
-    _tf.limit(_area.width(),_area.height());
+    _tf.limit(_area.width(), _area.height());
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_global_mutex);
+        _global_tf = currentTransform(_tf);
+    }
+
+    _layer_field_line->draw();
 }
+
 void Field::e_middle_alt() {
-//    GlobalSettings::instance()->setBallPlacementPos(::rx(e->x()), ::ry(e->y()));
+    GlobalSettings::instance()->setBallPlacementPos(_end.x(), _end.y());
 }
+
 void Field::e_middle_ctrl() {
-//    auto x1 = ::rx(e->x());
-//    auto x2 = ::rx(MiddleEvent::start.x());
-//    auto y1 = ::ry(e->y());
-//    auto y2 = ::ry(MiddleEvent::start.y());
-//    auto minX = std::min(x1, x2);
-//    auto maxX = std::max(x1, x2);
-//    auto minY = std::min(y1, y2);
-//    auto maxY = std::max(y1, y2);
-//    if(maxX - minX < MIN_LENGTH * zoomRatio || maxY - minY < MIN_LENGTH * zoomRatio)
-//        GlobalSettings::instance()->resetArea();
-//    else
-//        GlobalSettings::instance()->setArea(minX, maxX, minY, maxY);
-}
-void Field::wheelEvent (QWheelEvent *e) {
-    QPointF p;
-    {
-        std::shared_lock lock(_tf.mutex);
-        #if QT_VERSION >= QT_VERSION_CHECK(5, 14, 0)
-        p = _tf._.inverted().map(e->position());
-        #else
-        p = _tf._.inverted().map(e->pos());
-        #endif
+    const double minX = std::min(_start.x(), _end.x());
+    const double maxX = std::max(_start.x(), _end.x());
+    const double minY = std::min(_start.y(), _end.y());
+    const double maxY = std::max(_start.y(), _end.y());
+
+    if (maxX - minX < kMinSelectionLength || maxY - minY < kMinSelectionLength) {
+        GlobalSettings::instance()->resetArea();
+    } else {
+        GlobalSettings::instance()->setArea(minX, maxX, minY, maxY);
     }
-    auto ratio = e->angleDelta().y() < 0 ? 0.9 : 1/0.9;
+}
+
+#if QT_CONFIG(wheelevent)
+void Field::wheelEvent(QWheelEvent* event) {
+    if (_area.width() <= 0 || _area.height() <= 0) {
+        return;
+    }
+
+    const int delta = event->angleDelta().y();
+    if (delta == 0) {
+        return;
+    }
+
+    const QTransform cur = currentTransform(_tf);
+    const double currentScale = std::abs(cur.m11());
+    const double baseScale = std::min(double(_area.width()) / FP::_()->p_canvas_width,
+                                      double(_area.height()) / FP::_()->p_canvas_height);
+    if (baseScale <= 0.0) {
+        return;
+    }
+
+    const qreal oldRatio = clampValue(baseScale / currentScale, kZoomMin, 1.0);
+    qreal nextRatio = oldRatio + (delta < 0 ? kZoomStep : -kZoomStep);
+    nextRatio = clampValue(nextRatio, kZoomMin, qreal(1.0));
+    const double nextScale = baseScale / nextRatio;
+
+    bool ok = false;
+    const QTransform inv = cur.inverted(&ok);
+    if (!ok) {
+        return;
+    }
+
+    const QPointF cursor = event->position();
+    const QPointF world = inv.map(cursor);
+
+    QTransform next(nextScale,
+                    0,
+                    0,
+                    -nextScale,
+                    cursor.x() - nextScale * world.x(),
+                    cursor.y() + nextScale * world.y());
+
     {
         std::scoped_lock<std::shared_mutex> lock(_tf.mutex);
-        _tf._.translate(p.x(),p.y());
-        _tf._.scale(ratio,ratio);
-        _tf._.translate(-p.x(),-p.y());
+        _tf._ = next;
     }
-    _tf.limit(_area.width(),_area.height());
-    sendSignal();
+    _tf.limit(_area.width(), _area.height());
+
+    {
+        std::scoped_lock<std::shared_mutex> lock(_global_mutex);
+        _global_tf = currentTransform(_tf);
+    }
+
+    _layer_field_line->draw();
+    draw();
+    event->accept();
 }
-void Field::sendSignal(){
-    CInteraction::_()->_draw_signal.publish();
-}
+#endif

--- a/Client/src/field.cpp
+++ b/Client/src/field.cpp
@@ -52,6 +52,16 @@ T clampValue(T value, T minValue, T maxValue) {
     return std::max(minValue, std::min(value, maxValue));
 }
 
+QFont::Weight debugTextWeight(int rawWeight) {
+    if (rawWeight <= 0) {
+        return QFont::Normal;
+    }
+    // Qt5 code used 0-99 legacy weight values. Qt6 expects 100-900.
+    int mappedWeight = rawWeight <= 99 ? rawWeight * 10 : rawWeight;
+    mappedWeight = clampValue(mappedWeight, int(QFont::Thin), int(QFont::Black));
+    return static_cast<QFont::Weight>(mappedWeight);
+}
+
 const Msg::Robot* findRobotById(const OriginMessage& vision, int team, int id) {
     if (team < PARAM::BLUE || team > PARAM::YELLOW || id < 0 || id >= PARAM::ROBOTMAXID) {
         return nullptr;
@@ -194,8 +204,8 @@ void paintDebugMessages(QPainter& painter, const QTransform& tf, int team) {
             break;
         }
         case ZSS::Protocol::Debug_Msg_Debug_Type_TEXT:
-            font.setPointSizeF(std::max(8.0, std::abs(tf.m11()) * msg.text().size() * 0.01));
-            font.setWeight(static_cast<QFont::Weight>(msg.text().weight()));
+            font.setPointSizeF(std::max(10.0, std::abs(tf.m11()) * msg.text().size()));
+            font.setWeight(debugTextWeight(msg.text().weight()));
             painter.setFont(font);
             painter.drawText(tf.map(QPointF(msg.text().pos().x(), msg.text().pos().y())),
                              QString::fromStdString(msg.text().text()));

--- a/Client/src/field.h
+++ b/Client/src/field.h
@@ -3,24 +3,41 @@
 
 #include <QQuickPaintedItem>
 #include <mutex>
+#include <shared_mutex>
+#include <array>
 #include <QMouseEvent>
 #include <QPainter>
 #include <QPixmap>
 #include "layer.h"
 #include "visionmodule.h"
 #include "fieldconfig.h"
+
+class FieldLineLayer;
+class VisionLayer;
 class Field : public QQuickPaintedItem{
     Q_OBJECT
+    Q_PROPERTY(int type READ type WRITE setType)
+    Q_PROPERTY(bool draw READ ifDraw WRITE setDraw)
 public:
     Field(QQuickItem *parent = 0);
+    ~Field() override;
     void paint(QPainter* painter) override;
     Q_INVOKABLE void resize(int,int,bool update = true);
+    static float fieldXFromCoordinate(int);
+    static float fieldYFromCoordinate(int);
+    static void setSize(int width, int height);
+    int type() const { return _type; }
+    void setType(int t) { _type = t; }
+    bool ifDraw() const { return _draw; }
+    void setDraw(bool t) { _draw = t; }
     void mouseMoveEvent(QMouseEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseReleaseEvent(QMouseEvent *event) override;
 #if QT_CONFIG(wheelevent)
     void wheelEvent(QWheelEvent * event) override; // canvas scale
 #endif
+protected:
+    void geometryChange(const QRectF &newGeometry, const QRectF &oldGeometry) override;
 private:
     // event + left/right/middle + [none/ctrl/shift/alt] + [press/move/release]
     void e_left(); // ball || robot set position
@@ -37,6 +54,16 @@ private:
     Qt::MouseButtons _buttons;
     Qt::KeyboardModifiers _mouse_modifiers;
     QTransform _old_tf;
+    QPointF _start_screen;
+    QPointF _end_screen;
+    bool _pressed_robot = false;
+    bool _select_robots = false;
+    int _selected_count = 0;
+    int _selected_team = PARAM::BLUE;
+    std::array<int, PARAM::ROBOTNUM> _selected_ids;
+    OriginMessage _origin_robot;
+    double _display_data = 0;
+    int _event_stage = 0; // 0: press, 1: move, 2: release
 signals:
     void needDraw();
 public:
@@ -51,11 +78,20 @@ private:
     mutable std::shared_mutex _mutex;
     QRect _area;
     LayerNode _root;
+    FieldLineLayer* _layer_field_line = nullptr;
+    VisionLayer* _layer_vision = nullptr;
     zos::Subscriber<1> s_need_draw;
     FieldTransform _tf;
 private:
     QElapsedTimer _timer;
     bool _first = false;
+    int _type = 0;
+    bool _draw = true;
+private:
+    static std::shared_mutex _global_mutex;
+    static QTransform _global_tf;
+    static int _global_width;
+    static int _global_height;
 };
 
 #endif // __TINY_FIELD_H__

--- a/Client/src/interaction.cpp
+++ b/Client/src/interaction.cpp
@@ -9,6 +9,7 @@
 #include "simmodule.h"
 #include "rec_recorder.h"
 #include "networkinterfaces.h"
+#include <QCoreApplication>
 #include <QProcess>
 namespace {
 QProcess *medusaProcess = nullptr;
@@ -320,17 +321,29 @@ void Interaction::robotControl(int id, int team) {
 
 void Interaction::kill() {
     ZRecRecorder::instance()->stop();
-    QProcess killTask;
+
+    // Stop managed helper processes first.
+    controlMonitor(false);
+    controlMedusa(false);
+    controlMedusa2(false);
+    controlSim(false, false);
+    controlCrazy(false);
+
 #ifdef WIN32
 //    RefereeThread::instance()->disconnectTCP();
-    QString athena = "taskkill -im Client.exe -f";
-    QString medusa = "taskkill -im Core.exe -f";
-    //QString grSim = "taskkill -im grSim.exe -f";
+    QProcess::execute("taskkill", {"-im", "Core.exe", "-f"});
+    QProcess::execute("taskkill", {"-im", "Client.exe", "-f"});
 #else
-    QString athena = "pkill Client";
-    QString medusa = "pkill Core";
-    //QString grSim = "pkill grsim";
+    QProcess::execute("pkill", {"-x", "Core"});
+    QProcess::execute("pkill", {"-x", "grsim"});
+    QProcess::execute("pkill", {"-x", "Client"});
 #endif
+
+    // Always close current UI as a fallback in case external kill command fails.
+    if (QCoreApplication::instance()) {
+        QCoreApplication::quit();
+    }
+
     if (monitorProcess != nullptr) {
         if (monitorProcess->isOpen()) {
             monitorProcess->close();
@@ -338,10 +351,6 @@ void Interaction::kill() {
         delete monitorProcess;
         monitorProcess = nullptr;
     }
-    killTask.execute(medusa);
-    //killTask.execute(grSim);
-    killTask.execute(athena);
-    killTask.close();
 }
 bool Interaction::connectSerialPort(bool sw){
     if(sw){

--- a/Client/src/interaction.cpp
+++ b/Client/src/interaction.cpp
@@ -376,20 +376,40 @@ int Interaction::getFrequency(){
 
 void Interaction::updateTestScriptList(){
     QProcess process;
-    process.start("./tools/scan_tool scripts playname");
+    const QString program = QCoreApplication::applicationDirPath() + "/tools/scan_tool";
+    process.start(program, {"scripts", "playname"});
+    if (!process.waitForStarted(3000)) {
+        QTextStream(stdout) << "scan_tool start failed: " << program
+                            << " error=" << process.errorString() << "\n";
+        _test_script_show_name_list.clear();
+        return;
+    }
     process.waitForFinished(-1);
-    QString stdout = process.readAllStandardOutput();
-    _test_script_show_name_list = (stdout).split('\n');
-    _test_script_show_name_list.removeAll(QString(""));
+    const QString commandOutput = QString::fromUtf8(process.readAllStandardOutput());
+    _test_script_show_name_list = commandOutput.split('\n', Qt::SkipEmptyParts);
+    for (QString& item : _test_script_show_name_list) {
+        item = item.trimmed();
+    }
+    _test_script_show_name_list.removeAll(QString());
 }
 
 void Interaction::updateRefConfigList(){
     QProcess process;
-    process.start("./tools/scan_tool ref_configs");
+    const QString program = QCoreApplication::applicationDirPath() + "/tools/scan_tool";
+    process.start(program, {"ref_configs"});
+    if (!process.waitForStarted(3000)) {
+        QTextStream(stdout) << "scan_tool start failed: " << program
+                            << " error=" << process.errorString() << "\n";
+        _ref_config_show_name_list.clear();
+        return;
+    }
     process.waitForFinished(-1);
-    QString stdout = process.readAllStandardOutput();
-    _ref_config_show_name_list = (stdout).split('\n');
-    _ref_config_show_name_list.removeAll(QString(""));
+    const QString commandOutput = QString::fromUtf8(process.readAllStandardOutput());
+    _ref_config_show_name_list = commandOutput.split('\n', Qt::SkipEmptyParts);
+    for (QString& item : _ref_config_show_name_list) {
+        item = item.trimmed();
+    }
+    _ref_config_show_name_list.removeAll(QString());
 }
 
 

--- a/Client/src/interaction4field.cpp
+++ b/Client/src/interaction4field.cpp
@@ -21,12 +21,10 @@ void Interaction4Field::setCtrlC(){
     GlobalData::instance()->ctrlCMutex.unlock();
 }
 int Interaction4Field::getRealX(int x){// mm
-    // return (int)Field::fieldXFromCoordinate(x);
-    return 0; // MARKTODO
+    return int(Field::fieldXFromCoordinate(x));
 }
 int Interaction4Field::getRealY(int y){// mm
-    // return (int)Field::fieldYFromCoordinate(y);
-    return 0; // MARKTODO
+    return int(Field::fieldYFromCoordinate(y));
 }
 void Interaction4Field::setRecorder(bool isRecording) {
     if (isRecording) {
@@ -35,6 +33,3 @@ void Interaction4Field::setRecorder(bool isRecording) {
         ZRecRecorder::instance()->stop();
     }
 }
-
-void keyPress(QKeyEvent event);
-void keyRelease(QKeyEvent event);

--- a/Client/src/interaction4field.h
+++ b/Client/src/interaction4field.h
@@ -19,13 +19,11 @@ public:
     Q_INVOKABLE void setCtrlC();
     Q_INVOKABLE int getRealX(int);
     Q_INVOKABLE int getRealY(int);
+    Q_INVOKABLE void setSize(int width, int height) { Field::setSize(width, height); }
     Q_INVOKABLE void setRecorder(bool isRecording);
-//    Q_INVOKABLE void keyPress(QKeyEvent* event);
-//    Q_INVOKABLE void keyRelease(QKeyEvent* event);
     ~Interaction4Field();
-Q_SIGNALS:
-    void moveFieldSignal(int,int);
 signals:
+    void moveFieldSignal(int,int);
 public slots:
 };
 

--- a/Client/src/main.cpp
+++ b/Client/src/main.cpp
@@ -1,4 +1,6 @@
 #include <kddockwidgets/qtquick/Platform.h>
+#include <kddockwidgets/Config.h>
+#include <kddockwidgets/qtquick/ViewFactory.h>
 
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
@@ -43,14 +45,13 @@ void qmlRegister() {
     ZSS::LParamManager::instance()->clear();
 }
 
-// class CustomFrameworkWidgetFactory : public KDDockWidgets::QtQuick::ViewFactory{
-// public:
-//     ~CustomFrameworkWidgetFactory() override = default;
-//     QUrl titleBarFilename() const override{ return QUrl("qrc:/src/qml/CustomDW/TitleBar.qml"); }
-//     QUrl dockwidgetFilename() const override{ return QUrl("qrc:/src/qml/CustomDW/DockWidget.qml"); }
-//     QUrl frameFilename() const override{ return QUrl("qrc:/src/qml/CustomDW/Frame.qml"); }
-//     QUrl floatingWindowFilename() const override{ return QUrl("qrc:/src/qml/CustomDW/FloatingWindow.qml"); }
-// };
+class CustomFrameworkWidgetFactory : public KDDockWidgets::QtQuick::ViewFactory {
+public:
+    ~CustomFrameworkWidgetFactory() override = default;
+    QUrl titleBarFilename() const override { return QUrl("qrc:/src/qml/CustomDW/TitleBar.qml"); }
+    QUrl dockwidgetFilename() const override { return QUrl("qrc:/src/qml/CustomDW/DockWidget.qml"); }
+    QUrl floatingWindowFilename() const override { return QUrl("qrc:/src/qml/CustomDW/FloatingWindow.qml"); }
+};
 
 int main(int argc, char *argv[]) {
 #ifdef Q_OS_WIN
@@ -62,11 +63,14 @@ int main(int argc, char *argv[]) {
 #endif
     QGuiApplication app(argc, argv);
     KDDockWidgets::initFrontend(KDDockWidgets::FrontendType::QtQuick);
+    KDDockWidgets::Config::self().setViewFactory(new CustomFrameworkWidgetFactory());
     app.setOrganizationName("Turing-zero");
     app.setOrganizationDomain("turing-zero.com");
     qmlRegister();
     app.setFont(QFont("Microsoft YaHei", 9));
     QQmlApplicationEngine engine;
+    engine.addImportPath(QStringLiteral("qrc:/src/qml"));
+    engine.addImportPath(QStringLiteral(":/src/qml"));
     KDDockWidgets::QtQuick::Platform::instance()->setQmlEngine(&engine);
     engine.load(QUrl(QLatin1String("qrc:/src/qml/main_test.qml")));
     return app.exec();

--- a/Client/src/messageinfo.h
+++ b/Client/src/messageinfo.h
@@ -4,16 +4,16 @@
 #include <QAbstractListModel>
 #include <QStringList>
 #include <QQmlEngine>
+#include <QJSEngine>
 
 class MessageInfo : public QObject{
     Q_OBJECT
     Q_PROPERTY (char info READ info WRITE setInfo NOTIFY infoChanged)
 public:
     static QObject* instance(QQmlEngine* engine = nullptr, QJSEngine* scriptEngine = nullptr){
-        Q_UNUSED(engine)
-        Q_UNUSED(scriptEngine)
-        static MessageInfo* instance = new MessageInfo();
-        return instance;
+        QObject *parent = engine ? static_cast<QObject *>(engine)
+                                 : static_cast<QObject *>(scriptEngine);
+        return new MessageInfo(parent);
     }
     explicit MessageInfo(QObject *parent = Q_NULLPTR) : m_info(0x00){}
     ~MessageInfo(){}

--- a/Client/src/plotdisplay.cpp
+++ b/Client/src/plotdisplay.cpp
@@ -22,19 +22,27 @@ float h(float a){return -a/MAX_SPEED*MAP_HEIGHT;};
 }
 PlotDisplay::PlotDisplay(QQuickItem *parent)
     : QQuickPaintedItem (parent)
+    , s_need_draw("plot_draw_trigger", [this](const zos::Data&) {
+        QMetaObject::invokeMethod(this, [this]() { draw(); }, Qt::QueuedConnection);
+    })
     , pixmap(nullptr){
-    connect(VisionModule::instance(), SIGNAL(needDraw()), this, SLOT(draw()));
+    VisionModule::instance()->p_draw_signal.link(&s_need_draw);
     setImplicitWidth(200);
     setImplicitHeight(300);
     pixmap = new QPixmap(QSize(200, 300));
-    pixmapPainter.begin(pixmap);
-    pixmapPainter.setPen(Qt::NoPen);
-    pixmapPainter.setRenderHint(QPainter::Antialiasing, true);
-    pixmapPainter.setRenderHint(QPainter::TextAntialiasing, true);
+    area = QRect(0, 0, 200, 300);
+    if (pixmapPainter.begin(pixmap)) {
+        pixmapPainter.setPen(Qt::NoPen);
+        pixmapPainter.setRenderHint(QPainter::Antialiasing, true);
+        pixmapPainter.setRenderHint(QPainter::TextAntialiasing, true);
+    }
     init();
 }
 void PlotDisplay::paint(QPainter* painter) {
-    painter->drawPixmap(area, *pixmap);
+    if (pixmap == nullptr || pixmap->isNull()) {
+        return;
+    }
+    painter->drawPixmap(area.isValid() ? area : QRect(0, 0, pixmap->width(), pixmap->height()), *pixmap);
 }
 void PlotDisplay::draw() {
     repaint();
@@ -61,10 +69,18 @@ void PlotDisplay::initAxes(){
 }
 void PlotDisplay::repaint(){
     if(repaint_mutex.try_lock()){
+        if (pixmap == nullptr || pixmap->isNull() || !pixmapPainter.isActive()) {
+            repaint_mutex.unlock();
+            return;
+        }
         pixmap->fill(COLOR_BACKGROUND);
         paintAxes();
         paintData();
-        this->update(area);
+        if (area.isValid()) {
+            this->update(area);
+        } else {
+            this->update();
+        }
         repaint_mutex.unlock();
     }
 }
@@ -102,10 +118,22 @@ void PlotDisplay::paintData(){
     }
 }
 void PlotDisplay::resetSize(int width,int height){
-    pixmapPainter.end();
+    if (width <= 0 || height <= 0) {
+        return;
+    }
+    if (pixmapPainter.isActive()) {
+        pixmapPainter.end();
+    }
     delete pixmap;
-    pixmap = new QPixmap(QSize(this->property("width").toReal(), this->property("height").toReal()));
-    pixmapPainter.begin(pixmap);
-    area = QRect(0, 0, this->property("width").toReal(), this->property("height").toReal());
+    pixmap = new QPixmap(QSize(width, height));
+    if (pixmap == nullptr || pixmap->isNull()) {
+        area = QRect();
+        return;
+    }
+    if (!pixmapPainter.begin(pixmap)) {
+        area = QRect();
+        return;
+    }
+    area = QRect(0, 0, width, height);
     init();
 }

--- a/Client/src/plotdisplay.h
+++ b/Client/src/plotdisplay.h
@@ -7,6 +7,7 @@
 #include <QRect>
 #include <QMutex>
 #include <QPainterPath>
+#include "zos/core.h"
 class PlotDisplay : public QQuickPaintedItem{
     Q_OBJECT
     Q_PROPERTY(int type READ type WRITE setType)
@@ -31,6 +32,7 @@ private:
     float x();
     float y();
 private:
+    zos::Subscriber<1> s_need_draw;
     int _type;
     QPixmap *pixmap;
     QPainter pixmapPainter;

--- a/Client/src/qml/Components/NavView.qml
+++ b/Client/src/qml/Components/NavView.qml
@@ -1,0 +1,281 @@
+import QtQuick 2.15
+
+Item {
+    id: control
+    clip: true
+
+    property var items: ["Origin", "Filtered Blue", "Filtered Yellow"]
+    property var itemWeights: []
+    property int currentIndex: 0
+    property int cellHeight: 38
+    property int cellWidth: 800
+    property int minCellWidth: 80
+    property int tabPadding: 12
+    property int tabSpacing: 4
+    property int sidePadding: 6
+    property int verticalPadding: 2
+    property int indicatorWidth: 3
+    property real indicatorRadius: 1.5
+    property int panelRadius: 5
+    property int itemRadius: 4
+    property color panelColor: "#3d3d3d"
+    property color hoverColor: "#4a4a4a"
+    property color pressedColor: "#434343"
+    property color activeColor: "#505050"
+    property color normalColor: "transparent"
+    property color textColor: "#d8d8d8"
+    property color activeTextColor: "#ffffff"
+    property color accentColor: "#00a6ff"
+    property color borderColor: "#2d2d2d"
+
+    signal itemClicked(int index, string title)
+
+    implicitHeight: cellHeight + verticalPadding * 2
+    implicitWidth: cellWidth
+
+    readonly property int tabCount: Math.max(1, items ? items.length : 0)
+    readonly property int availableTabWidth: Math.max(0,
+        width - sidePadding * 2 - tabSpacing * (tabCount - 1))
+    readonly property real totalWeight: {
+        if (!items || items.length <= 0) {
+            return 1
+        }
+        var sum = 0
+        for (var i = 0; i < items.length; i++) {
+            sum += weightAt(i)
+        }
+        return Math.max(1, sum)
+    }
+    readonly property bool canApplyMinWidth: availableTabWidth >= minCellWidth * tabCount
+
+    function itemTitleAt(index) {
+        if (!items || index < 0 || index >= items.length) {
+            return ""
+        }
+        var item = items[index]
+        if (typeof item === "string") {
+            return item
+        }
+        if (item && item.title !== undefined) {
+            return item.title
+        }
+        return String(item)
+    }
+
+    function weightAt(index) {
+        var weight = 1
+        if (itemWeights && index >= 0 && index < itemWeights.length) {
+            weight = Number(itemWeights[index])
+        } else if (items && index >= 0 && index < items.length) {
+            var item = items[index]
+            if (item && item.weight !== undefined) {
+                weight = Number(item.weight)
+            }
+        }
+        if (isNaN(weight) || weight <= 0) {
+            return 1
+        }
+        return weight
+    }
+
+    function tabWidthAt(index) {
+        var weightedWidth = Math.floor(availableTabWidth * weightAt(index) / totalWeight)
+        if (canApplyMinWidth) {
+            return Math.max(minCellWidth, weightedWidth)
+        }
+        return Math.max(0, weightedWidth)
+    }
+
+    function tabXAt(index) {
+        if (!items || index < 0 || index >= items.length) {
+            return sidePadding
+        }
+        var x = sidePadding
+        for (var i = 0; i < index; i++) {
+            x += tabWidthAt(i) + tabSpacing
+        }
+        return x
+    }
+
+    function safeIndex(index) {
+        if (!items || items.length <= 0) {
+            return -1
+        }
+        return Math.max(0, Math.min(index, items.length - 1))
+    }
+
+    onCurrentIndexChanged: {
+        var idx = safeIndex(currentIndex)
+        if (idx !== currentIndex) {
+            currentIndex = idx
+            return
+        }
+        switchPulse.restart()
+    }
+
+    onItemsChanged: {
+        var idx = safeIndex(currentIndex)
+        if (idx !== currentIndex) {
+            currentIndex = idx
+        }
+    }
+
+    Rectangle {
+        anchors.fill: parent
+        radius: control.panelRadius
+        color: control.panelColor
+        border.color: control.borderColor
+        border.width: 1
+    }
+
+    Rectangle {
+        id: activeBackground
+        visible: control.currentIndex >= 0 && control.items && control.items.length > 0
+        x: control.tabXAt(control.currentIndex)
+        y: control.verticalPadding
+        width: control.tabWidthAt(control.currentIndex)
+        height: control.cellHeight - control.verticalPadding * 2
+        radius: control.itemRadius
+        color: control.activeColor
+        transformOrigin: Item.Center
+
+        Behavior on x {
+            NumberAnimation {
+                duration: 180
+                easing.type: Easing.OutCubic
+            }
+        }
+
+        Behavior on width {
+            NumberAnimation {
+                duration: 180
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    Rectangle {
+        id: activeIndicator
+        visible: activeBackground.visible
+        width: control.indicatorWidth
+        height: 18
+        radius: control.indicatorRadius
+        color: control.accentColor
+        x: activeBackground.x + 6
+        y: activeBackground.y + (activeBackground.height - height) / 2
+
+        Behavior on x {
+            NumberAnimation {
+                duration: 90
+                easing.type: Easing.OutCubic
+            }
+        }
+    }
+
+    SequentialAnimation {
+        id: switchPulse
+        NumberAnimation {
+            target: activeBackground
+            property: "scale"
+            to: 1.02
+            duration: 60
+            easing.type: Easing.OutQuad
+        }
+        NumberAnimation {
+            target: activeBackground
+            property: "scale"
+            to: 1.0
+            duration: 120
+            easing.type: Easing.OutCubic
+        }
+    }
+
+    Row {
+        id: tabsRow
+        anchors.left: parent.left
+        anchors.leftMargin: control.sidePadding
+        anchors.verticalCenter: parent.verticalCenter
+        spacing: control.tabSpacing
+
+        Repeater {
+            model: control.items
+
+            delegate: Item {
+                width: control.tabWidthAt(index)
+                height: control.cellHeight
+
+                Rectangle {
+                    id: itemFace
+                    anchors.fill: parent
+                    anchors.topMargin: control.verticalPadding
+                    anchors.bottomMargin: control.verticalPadding
+                    radius: control.itemRadius
+                    color: {
+                        if (index === control.currentIndex) {
+                            return "transparent"
+                        }
+                        if (mouseArea.pressed) {
+                            return control.pressedColor
+                        }
+                        if (mouseArea.containsMouse) {
+                            return control.hoverColor
+                        }
+                        return control.normalColor
+                    }
+                    scale: mouseArea.pressed ? 0.98 : 1.0
+
+                    Behavior on color {
+                        ColorAnimation {
+                            duration: 110
+                        }
+                    }
+
+                    Behavior on scale {
+                        NumberAnimation {
+                            duration: 70
+                            easing.type: Easing.OutCubic
+                        }
+                    }
+                }
+
+                Text {
+                    id: titleText
+                    anchors.verticalCenter: itemFace.verticalCenter
+                    anchors.left: itemFace.left
+                    anchors.leftMargin: index === control.currentIndex ? 16 : 12
+                    anchors.right: itemFace.right
+                    anchors.rightMargin: 12
+                    text: control.itemTitleAt(index)
+                    color: index === control.currentIndex ? control.activeTextColor : control.textColor
+                    font.pixelSize: 13
+                    font.bold: false
+                    horizontalAlignment: Text.AlignLeft
+                    elide: Text.ElideRight
+
+                    Behavior on color {
+                        ColorAnimation {
+                            duration: 140
+                        }
+                    }
+                }
+
+                MouseArea {
+                    id: mouseArea
+                    anchors.fill: parent
+                    hoverEnabled: true
+                    onClicked: {
+                        control.currentIndex = index
+                        control.itemClicked(index, control.itemTitleAt(index))
+                    }
+                }
+
+                Behavior on x {
+                    NumberAnimation {
+                        duration: 167
+                        easing.type: Easing.OutCubic
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Client/src/qml/Components/qmldir
+++ b/Client/src/qml/Components/qmldir
@@ -8,3 +8,4 @@ CComboBox 1.0 CComboBox.qml
 CSpinBox 1.0 CSpinBox.qml
 CText 1.0 CText.qml
 CLight 1.0 CLight.qml
+NavView 1.0 NavView.qml

--- a/Client/src/qml/ControlBoard.qml
+++ b/Client/src/qml/ControlBoard.qml
@@ -322,20 +322,22 @@ Page{
                             height:parent.height;
                             text: "TEST"
                         }
-                        ZComboBox{
+                        ZSuggestComboBox{
                             id:test_script_blue;
                             width:parent.width/2 - test_script_mode_blue.width;
                             height:parent.height;
+                            placeholderText: qsTr("Search TestPlay")
                         }
                         CheckBox{
                             id:test_script_mode_yellow;
                             height:parent.height;
                             text: "TEST"
                         }
-                        ZComboBox{
+                        ZSuggestComboBox{
                             id:test_script_yellow;
                             width:parent.width/2 - test_script_mode_yellow.width - test_script_refresh.width;
                             height:parent.height;
+                            placeholderText: qsTr("Search TestPlay")
                         }
                         Button{
                             id:test_script_refresh;

--- a/Client/src/qml/ControlBoard.qml
+++ b/Client/src/qml/ControlBoard.qml
@@ -1,7 +1,7 @@
 ﻿import QtQuick 2.10
-import QtQuick.Controls
-import QtQuick.Dialogs
-import QtQuick.Layouts
+import QtQuick.Controls 2.15
+import QtQuick.Dialogs 6.2
+import QtQuick.Layouts 1.15
 import ZSS 1.0 as ZSS
 Page{
     id:control;

--- a/Client/src/qml/ControlBoard.qml
+++ b/Client/src/qml/ControlBoard.qml
@@ -5,6 +5,7 @@ import QtQuick.Layouts
 import ZSS 1.0 as ZSS
 Page{
     id:control;
+    property var interaction: ZSS.Interaction
     property bool socketConnect : false;
     property bool radioConnect : false;
     property bool medusaConnect : false;
@@ -38,9 +39,6 @@ Page{
         id: eventlabel
     }
 
-    ZSS.Interaction{
-        id:interaction;
-    }
     ZSS.Interaction4Field{
         id:interaction4field
     }
@@ -534,16 +532,14 @@ Page{
                            FileDialog {
                                id:fdrs
                                title: "Please select"
-                               selectExisting: true
-                               selectFolder: false
-                               selectMultiple: false
+                               fileMode: FileDialog.OpenFile
                                nameFilters: ["Rec files (*.log)"]
                                onAccepted: {
                                    if (control.isReplaying) ZSS.RecSlider.toggleStopped();
                                    control.isReplaying = false;
                                    rectimer.running = false;
-                                   console.log("You chose: " + fdrs.fileUrl);
-                                   ZSS.RecSlider.loadFile(fdrs.fileUrl);
+                                   console.log("You chose: " + fdrs.selectedFile);
+                                   ZSS.RecSlider.loadFile(fdrs.selectedFile);
                                    recslider.to = ZSS.RecSlider.maximumValue;
                                    recslider.stepSize = ZSS.RecSlider.stepSize;
                                    recslider.value = 0;

--- a/Client/src/qml/CustomDW/DockStyle.qml
+++ b/Client/src/qml/CustomDW/DockStyle.qml
@@ -1,0 +1,145 @@
+pragma Singleton
+import QtQuick 2.15
+
+QtObject {
+    id: root
+
+    // A lightweight qss-like input. Example:
+    // "title-bg:#1f2733; title-fg:#eef3ff; frame-radius:8; tab-active-bg:#2f7dff"
+    property string styleSheet: ""
+
+    property color titleBarBackground: "#1f2733"
+    property color titleBarBorderColor: "#2b3646"
+    property color titleTextColor: "#eef3ff"
+    property color buttonTextColor: "#d8e1f0"
+    property color buttonHoverBackground: "#314054"
+    property color buttonPressedBackground: "#223044"
+
+    property color frameBackground: "#0f141c"
+    property color frameBorderColor: "#2b3646"
+    property int frameBorderWidth: 1
+    property int frameRadius: 8
+
+    property color dockWidgetBackground: frameBackground
+
+    property color tabBackground: "#16202c"
+    property color tabBorderColor: "#253141"
+    property color tabTextColor: "#8ea0b8"
+    property color tabActiveBackground: "#2f7dff"
+    property color tabActiveTextColor: "#ffffff"
+
+    property color floatingBorderColor: "#2b3646"
+    property int floatingBorderWidth: 1
+    property int floatingMargins: 4
+
+    property int titleBarHeight: 36
+    property int titleBarRadius: 8
+    property int tabBarHeight: 34
+    property int titleHorizontalPadding: 12
+    property int buttonSize: 22
+
+    onStyleSheetChanged: applyStyleSheet(styleSheet)
+
+    function toNumberOrDefault(value, fallback) {
+        var n = Number(value)
+        return isNaN(n) ? fallback : n
+    }
+
+    function applyStyleSheet(sheet) {
+        if (!sheet || sheet.trim().length === 0)
+            return
+
+        var entries = sheet.split(";")
+        for (var i = 0; i < entries.length; ++i) {
+            var line = entries[i].trim()
+            if (!line)
+                continue
+
+            var sep = line.indexOf(":")
+            if (sep <= 0)
+                continue
+
+            var key = line.slice(0, sep).trim().toLowerCase()
+            var value = line.slice(sep + 1).trim()
+            if (!value)
+                continue
+
+            switch (key) {
+            case "title-bg":
+                titleBarBackground = value
+                break
+            case "title-border":
+                titleBarBorderColor = value
+                break
+            case "title-fg":
+                titleTextColor = value
+                break
+            case "btn-fg":
+                buttonTextColor = value
+                break
+            case "btn-hover-bg":
+                buttonHoverBackground = value
+                break
+            case "btn-pressed-bg":
+                buttonPressedBackground = value
+                break
+            case "frame-bg":
+                frameBackground = value
+                break
+            case "frame-border":
+                frameBorderColor = value
+                break
+            case "frame-border-width":
+                frameBorderWidth = toNumberOrDefault(value, frameBorderWidth)
+                break
+            case "frame-radius":
+                frameRadius = toNumberOrDefault(value, frameRadius)
+                break
+            case "dock-bg":
+                dockWidgetBackground = value
+                break
+            case "tab-bg":
+                tabBackground = value
+                break
+            case "tab-border":
+                tabBorderColor = value
+                break
+            case "tab-fg":
+                tabTextColor = value
+                break
+            case "tab-active-bg":
+                tabActiveBackground = value
+                break
+            case "tab-active-fg":
+                tabActiveTextColor = value
+                break
+            case "floating-border":
+                floatingBorderColor = value
+                break
+            case "floating-border-width":
+                floatingBorderWidth = toNumberOrDefault(value, floatingBorderWidth)
+                break
+            case "floating-margins":
+                floatingMargins = toNumberOrDefault(value, floatingMargins)
+                break
+            case "title-height":
+                titleBarHeight = toNumberOrDefault(value, titleBarHeight)
+                break
+            case "title-radius":
+                titleBarRadius = toNumberOrDefault(value, titleBarRadius)
+                break
+            case "tab-height":
+                tabBarHeight = toNumberOrDefault(value, tabBarHeight)
+                break
+            case "title-padding":
+                titleHorizontalPadding = toNumberOrDefault(value, titleHorizontalPadding)
+                break
+            case "btn-size":
+                buttonSize = toNumberOrDefault(value, buttonSize)
+                break
+            default:
+                break
+            }
+        }
+    }
+}

--- a/Client/src/qml/CustomDW/DockWidget.qml
+++ b/Client/src/qml/CustomDW/DockWidget.qml
@@ -10,10 +10,11 @@
 */
 
 import QtQuick 2.9
+import CustomDW 1.0
 
 Rectangle {
     id: root
-    color:"transparent"
+  color: DockStyle.dockWidgetBackground
     readonly property QtObject dockWidgetCpp: parent
     anchors.fill: parent
 }

--- a/Client/src/qml/CustomDW/FloatingWindow.qml
+++ b/Client/src/qml/CustomDW/FloatingWindow.qml
@@ -10,22 +10,26 @@
 */
 
 import QtQuick 2.9
-import "qrc:/kddockwidgets/private/quick/qml/" as KDDW
+import "qrc:/kddockwidgets/qtquick/views/qml/" as KDDW
+import CustomDW 1.0
 
 Rectangle {
     id: root
     readonly property QtObject floatingWindowCpp: parent
     readonly property QtObject titleBarCpp: floatingWindowCpp ? floatingWindowCpp.titleBar : null
     readonly property QtObject dropAreaCpp: floatingWindowCpp ? floatingWindowCpp.dropArea : null
-    readonly property int titleBarHeight: titleBar.heightWhenVisible
-    property int margins: 4
+    readonly property int titleBarHeight: (titleBar.item ? titleBar.item.heightWhenVisible : 0)
+    property int margins: DockStyle.floatingMargins
 
     anchors.fill: parent
 
-    color: "transparent"
+    radius: DockStyle.frameRadius
+    antialiasing: true
+    clip: true
+    color: DockStyle.frameBackground
     border {
-        color: "#666666"
-        width: 1
+        color: DockStyle.floatingBorderColor
+        width: DockStyle.floatingBorderWidth
     }
 
     onTitleBarHeightChanged: {
@@ -36,8 +40,8 @@ Rectangle {
     Loader {
         id: titleBar
         readonly property QtObject titleBarCpp: root.titleBarCpp
-        readonly property int heightWhenVisible: item.heightWhenVisible
-        source: _kddw_widgetFactory.titleBarFilename()
+        readonly property int heightWhenVisible: item ? item.heightWhenVisible : 0
+        source: "qrc:/src/qml/CustomDW/TitleBar.qml"
 
         anchors {
             top:  parent ? parent.top : undefined

--- a/Client/src/qml/CustomDW/Frame.qml
+++ b/Client/src/qml/CustomDW/Frame.qml
@@ -12,167 +12,52 @@
 import QtQuick 2.9
 import QtQuick.Controls 2.9
 import QtQuick.Layouts 1.9
-import "qrc:/kddockwidgets/private/quick/qml/" as KDDW
-import com.kdab.dockwidgets 1.0
+import com.kdab.dockwidgets 2.0
+import CustomDW 1.0
 
 Rectangle {
     id: root
 
-    property QtObject frameCpp
-    readonly property QtObject titleBarCpp: frameCpp ? frameCpp.titleBar : null
+    property QtObject groupCpp
+    readonly property QtObject titleBarCpp: groupCpp ? groupCpp.titleBar : null
     readonly property int nonContentsHeight: (titleBar.item ? titleBar.item.heightWhenVisible : 0) + tabbar.implicitHeight + (2 * contentsMargin) + titleBarContentsMargin
     property int contentsMargin: isMDI ? 2 : 2
-    property int titleBarContentsMargin: 1
-    property bool hasCustomMouseEventRedirector: false
+    property int titleBarContentsMargin: 0
     property int mouseResizeMargin: 8
-    readonly property bool isMDI: frameCpp && frameCpp.isMDI
-    readonly property bool resizeAllowed: root.isMDI && !_kddwDragController.isDragging && _kddwDockRegistry && (!_kddwDockRegistry.frameInMDIResize || _kddwDockRegistry.frameInMDIResize === frameCpp)
+    readonly property bool isMDI: groupCpp && groupCpp.isMDI
+    readonly property bool hasCustomMouseEventRedirector: false
+    readonly property bool isFixedHeight: groupCpp && groupCpp.isFixedHeight
+    readonly property bool isFixedWidth: groupCpp && groupCpp.isFixedWidth
+    readonly property bool resizeAllowed: root.isMDI && !Singletons.helpers.isDragging && Singletons.dockRegistry && (!Singletons.helpers.groupViewInMDIResize || Singletons.helpers.groupViewInMDIResize === groupCpp)
     property alias tabBarHeight: tabbar.height
 
     anchors.fill: parent
 
-    radius: 2
-    color: "transparent"
+    radius: DockStyle.frameRadius
+    color: DockStyle.frameBackground
     border {
-        color: "#b8b8b8"
-        width: 0
+        color: DockStyle.frameBorderColor
+        width: DockStyle.frameBorderWidth
     }
 
-    onFrameCppChanged: {
-        if (frameCpp) {
-            frameCpp.setStackLayout(stackLayout);
+    onGroupCppChanged: {
+        if (groupCpp) {
+            groupCpp.setStackLayout(stackLayout);
         }
     }
 
     onNonContentsHeightChanged: {
-        if (frameCpp)
-            frameCpp.geometryUpdated();
+        if (groupCpp)
+            groupCpp.geometryUpdated();
     }
 
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            left: parent ? parent.left : undefined
-            top: parent ? parent.top : undefined
-            bottom: parent ? parent.bottom : undefined
-        }
-
-        width: resizeMargin
-        z: 100
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Left
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            right: parent ? parent.right : undefined
-            top: parent ? parent.top : undefined
-            bottom: parent ? parent.bottom : undefined
-        }
-
-        width: resizeMargin
-        z: 100
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Right
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            right: parent ? parent.right : undefined
-            top: parent ? parent.top : undefined
-            left: parent ? parent.left : undefined
-        }
-
-        height: resizeMargin
-        z: 100
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Top
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            right: parent ? parent.right : undefined
-            left: parent ? parent.left : undefined
-            bottom: parent ?  parent.bottom : undefined
-        }
-
-        height: resizeMargin
-        z: 100
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Bottom
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            right: parent ? parent.right : undefined
-            bottom: parent ? parent.bottom : undefined
-        }
-
-        height: width
-        width: resizeMargin
-        z: 101
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Bottom | KDDockWidgets.CursorPosition_Right
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            left:  parent ? parent.left : undefined
-            top:  parent ? parent.top : undefined
-        }
-
-        height: width
-        width: resizeMargin
-        z: 101
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Top | KDDockWidgets.CursorPosition_Left
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            right: parent ? parent.right : undefined
-            top: parent ? parent.top : undefined
-        }
-
-        height: width
-        width: resizeMargin
-        z: 101
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Top | KDDockWidgets.CursorPosition_Right
-    }
-
-    KDDW.ResizeHandlerHelper {
-        anchors {
-            left: parent ? parent.left : undefined
-            bottom: parent ? parent.bottom : undefined
-        }
-
-        height: width
-        width: resizeMargin
-        z: 101
-        frameCpp: root.frameCpp
-        resizeAllowed: root.resizeAllowed
-        resizeMargin: root.mouseResizeMargin
-        cursorPosition: KDDockWidgets.CursorPosition_Left | KDDockWidgets.CursorPosition_Bottom
-    }
+    // This KDDockWidgets build does not ship MDIResizeHandlerHelper.qml;
+    // keep frame creation compatible by skipping those helper items.
 
     Loader {
         id: titleBar
         readonly property QtObject titleBarCpp: root.titleBarCpp
-        source: frameCpp ? _kddw_widgetFactory.titleBarFilename()
+        source: groupCpp ? Singletons.widgetFactory.titleBarFilename()
                          : ""
 
         anchors {
@@ -186,9 +71,9 @@ Rectangle {
     }
 
     Connections {
-        target: frameCpp
+        target: groupCpp
         function onCurrentIndexChanged() {
-            tabbar.currentIndex = frameCpp.currentIndex;
+            tabbar.currentIndex = groupCpp.currentIndex;
         }
     }
 
@@ -203,17 +88,23 @@ Rectangle {
 
     TabBar {
         id: tabbar
-        readonly property QtObject tabBarCpp: root.frameCpp ? root.frameCpp.tabWidget.tabBar
+        readonly property QtObject tabBarCpp: root.groupCpp ? root.groupCpp.tabWidget.tabBar
                                                             : null
         visible: count > 1
-        height: visible ? 40 : 0
+        height: visible ? DockStyle.tabBarHeight : 0
+
+        background: Rectangle {
+            color: DockStyle.tabBackground
+            border.color: DockStyle.tabBorderColor
+            border.width: 1
+        }
 
         anchors {
             left: parent ? parent.left : undefined
             right: parent ? parent.right : undefined
             top: (titleBar && titleBar.visible) ? titleBar.bottom
                                                 : (parent ? parent.top : undefined)
-            topMargin: 1
+            topMargin: 0
             leftMargin: 1
             rightMargin: 1
         }
@@ -221,8 +112,8 @@ Rectangle {
         width: parent ? parent.width : 0
 
         onCurrentIndexChanged: {
-            if (root && root.frameCpp)
-                root.frameCpp.tabWidget.setCurrentDockWidget(currentIndex);
+            if (root && root.groupCpp)
+                root.groupCpp.tabWidget.setCurrentDockWidget(currentIndex);
         }
 
         onTabBarCppChanged: {
@@ -236,13 +127,19 @@ Rectangle {
         }
 
         Repeater {
-            model: root.frameCpp ? root.frameCpp.tabWidget.dockWidgetModel : 0
+            model: root.groupCpp ? root.groupCpp.tabWidget.dockWidgetModel : 0
             TabButton {
                 property bool selected: tabbar.currentIndex == index
+                background: Rectangle {
+                    color: parent.selected ? DockStyle.tabActiveBackground : "transparent"
+                    radius: 4
+                    border.color: DockStyle.tabBorderColor
+                    border.width: parent.selected ? 1 : 0
+                }
                 contentItem: Text {
                     text: title
                     font.weight: Font.Medium
-                    color: selected ? "#000" : "#777"
+                    color: selected ? DockStyle.tabActiveTextColor : DockStyle.tabTextColor
                     horizontalAlignment: Text.AlignHCenter
                     verticalAlignment: Text.AlignVCenter
                     elide: Text.ElideRight

--- a/Client/src/qml/CustomDW/TitleBar.qml
+++ b/Client/src/qml/CustomDW/TitleBar.qml
@@ -1,54 +1,360 @@
-import QtQuick 2.12
-import "qrc:/kddockwidgets/private/quick/qml/" as KDDW
-import Components 1.0 as Z
-import Theme 1.0
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
+import CustomDW 1.0
 
-KDDW.TitleBarBase{
+Rectangle {
     id: root
-    color: T.__c["main2"][T.i_main]
-    Text {
-        color: T.__c["accent"][T.i_main]
-        font.bold: true
-        text: root.title
-        anchors {
-            left: parent.left
-            leftMargin: 10
-            verticalCenter: root.verticalCenter
+
+    // Compatible with KDDockWidgets QtQuick title bar contract.
+    readonly property QtObject titleBarCpp: parent ? parent.titleBarCpp : null
+    readonly property string title: titleBarCpp ? titleBarCpp.title : ""
+    readonly property bool floatButtonVisible: titleBarCpp ? titleBarCpp.floatButtonVisible : false
+    readonly property bool closeButtonEnabled: titleBarCpp ? titleBarCpp.closeButtonEnabled : false
+    readonly property bool maximizeButtonVisible: titleBarCpp ? titleBarCpp.maximizeButtonVisible : false
+    readonly property bool minimizeButtonVisible: titleBarCpp ? titleBarCpp.minimizeButtonVisible : false
+    readonly property bool maximizeUsesRestoreIcon: titleBarCpp ? titleBarCpp.maximizeUsesRestoreIcon : false
+    readonly property bool isFocused: titleBarCpp ? titleBarCpp.isFocused : false
+    readonly property bool showFloatWindowButton: floatButtonVisible
+    readonly property bool showMaximizeWindowButton: !showFloatWindowButton && maximizeButtonVisible
+
+    property int trafficButtonSize: 8
+    property int trafficButtonHitSize: 16
+    property int trafficSpacing: 4
+
+    property int heightWhenVisible: Math.max(DockStyle.titleBarHeight, 28)
+
+    signal closeButtonClicked()
+    signal floatButtonClicked()
+    signal maximizeButtonClicked()
+    signal minimizeButtonClicked()
+
+    visible: titleBarCpp && titleBarCpp.visible
+    height: visible ? heightWhenVisible : 0
+    implicitHeight: heightWhenVisible
+
+    radius: DockStyle.titleBarRadius
+    border.color: DockStyle.titleBarBorderColor
+    border.width: 1
+    color: "transparent"
+    gradient: Gradient {
+        GradientStop { position: 0.0; color: isFocused ? DockStyle.titleBarBackground : Qt.darker(DockStyle.titleBarBackground, 1.15) }
+        GradientStop { position: 1.0; color: isFocused ? Qt.darker(DockStyle.titleBarBackground, 1.08) : Qt.darker(DockStyle.titleBarBackground, 1.25) }
+    }
+
+    MouseArea {
+        id: titleBarDragMouseArea
+        objectName: "titleBarMouseArea"
+        anchors.fill: parent
+        acceptedButtons: Qt.LeftButton
+        onDoubleClicked: {
+            if (root.titleBarCpp)
+                root.titleBarCpp.onDoubleClicked()
         }
     }
-    Z.CButton {
-        id: floatingButton
-        fillWidth: false
-        visible: root.floatButtonVisible
-        height: root.height - 15
-        width: height
-        iconFull: true
-        source:"/resource/icon/window_maximize.png"
-        anchors {
-            right: root.right
-            rightMargin: 30
-            verticalCenter: root.verticalCenter
+
+    RowLayout {
+        anchors.fill: parent
+        anchors.leftMargin: 10
+        anchors.rightMargin: 10
+        spacing: 10
+
+        Item {
+            id: leftButtons
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredWidth: root.trafficButtonHitSize * 3 + root.trafficSpacing * 2
+            Layout.preferredHeight: root.trafficButtonHitSize
+
+            Row {
+                anchors.verticalCenter: parent.verticalCenter
+                spacing: root.trafficSpacing
+
+                ToolButton {
+                    id: closeButton
+                    objectName: "closeButton"
+                    enabled: root.closeButtonEnabled
+                    width: root.trafficButtonHitSize
+                    height: root.trafficButtonHitSize
+                    hoverEnabled: true
+                    onClicked: root.closeButtonClicked()
+
+                    contentItem: Item {
+                        anchors.fill: parent
+                        opacity: closeButton.hovered ? 0.82 : 0.0
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 6
+                            height: 1
+                            radius: 1
+                            color: "#65131a"
+                            rotation: 45
+                        }
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 6
+                            height: 1
+                            radius: 1
+                            color: "#65131a"
+                            rotation: -45
+                        }
+
+                        Behavior on opacity { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+                    }
+
+                    background: Rectangle {
+                        implicitWidth: root.trafficButtonSize
+                        implicitHeight: root.trafficButtonSize
+                        anchors.centerIn: parent
+                        antialiasing: true
+                        radius: width / 2
+                        border.width: 0.7
+                        border.color: Qt.darker("#ff5f57", 1.12)
+                        color: closeButton.down ? "#ea4e47" : (closeButton.hovered ? "#ff5f57" : "#ff6b63")
+                        scale: closeButton.down ? 0.95 : 1.0
+
+                        Rectangle {
+                            anchors.fill: parent
+                            antialiasing: true
+                            radius: parent.radius
+                            border.width: 0
+                            gradient: Gradient {
+                                GradientStop { position: 0.0; color: "#2fffffff" }
+                                GradientStop { position: 1.0; color: "#00000000" }
+                            }
+                        }
+
+                        Behavior on color { ColorAnimation { duration: 140; easing.type: Easing.OutCubic } }
+                        Behavior on scale { NumberAnimation { duration: 90; easing.type: Easing.OutQuad } }
+                    }
+                }
+
+                ToolButton {
+                    id: minimizeButton
+                    objectName: "minimizeButton"
+                    visible: true
+                    enabled: root.minimizeButtonVisible
+                    width: root.trafficButtonHitSize
+                    height: root.trafficButtonHitSize
+                    hoverEnabled: true
+                    onClicked: root.minimizeButtonClicked()
+
+                    contentItem: Item {
+                        anchors.fill: parent
+                        opacity: minimizeButton.hovered ? 0.82 : 0.0
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 6
+                            height: 1
+                            radius: 1
+                            color: "#735516"
+                        }
+
+                        Behavior on opacity { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+                    }
+
+                    background: Rectangle {
+                        implicitWidth: root.trafficButtonSize
+                        implicitHeight: root.trafficButtonSize
+                        anchors.centerIn: parent
+                        antialiasing: true
+                        radius: width / 2
+                        border.width: 0.7
+                        border.color: Qt.darker("#ffbd2e", 1.14)
+                        color: minimizeButton.down ? "#ebb02a" : (minimizeButton.hovered ? "#ffbd2e" : "#ffc84f")
+                        scale: minimizeButton.down ? 0.95 : 1.0
+                        opacity: minimizeButton.enabled ? 1.0 : 0.55
+
+                        Rectangle {
+                            anchors.fill: parent
+                            antialiasing: true
+                            radius: parent.radius
+                            border.width: 0
+                            gradient: Gradient {
+                                GradientStop { position: 0.0; color: "#30ffffff" }
+                                GradientStop { position: 1.0; color: "#00000000" }
+                            }
+                        }
+
+                        Behavior on color { ColorAnimation { duration: 140; easing.type: Easing.OutCubic } }
+                        Behavior on scale { NumberAnimation { duration: 90; easing.type: Easing.OutQuad } }
+                        Behavior on opacity { NumberAnimation { duration: 140; easing.type: Easing.OutCubic } }
+                    }
+                }
+
+                ToolButton {
+                    id: floatButton
+                    objectName: "floatButton"
+                    visible: root.showFloatWindowButton
+                    enabled: root.floatButtonVisible
+                    width: root.trafficButtonHitSize
+                    height: root.trafficButtonHitSize
+                    hoverEnabled: true
+                    onClicked: root.floatButtonClicked()
+
+                    contentItem: Item {
+                        anchors.fill: parent
+                        opacity: floatButton.hovered ? 0.82 : 0.0
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            anchors.horizontalCenterOffset: -1
+                            anchors.verticalCenterOffset: 1
+                            width: 5
+                            height: 4
+                            color: "transparent"
+                            border.width: 1
+                            border.color: "#1c5f31"
+                            radius: 1
+                        }
+                        Rectangle {
+                            anchors.centerIn: parent
+                            anchors.horizontalCenterOffset: 2
+                            anchors.verticalCenterOffset: -2
+                            width: 5
+                            height: 4
+                            color: "transparent"
+                            border.width: 1
+                            border.color: "#1c5f31"
+                            radius: 1
+                        }
+
+                        Behavior on opacity { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+                    }
+
+                    background: Rectangle {
+                        implicitWidth: root.trafficButtonSize
+                        implicitHeight: root.trafficButtonSize
+                        anchors.centerIn: parent
+                        antialiasing: true
+                        radius: width / 2
+                        border.width: 0.7
+                        border.color: Qt.darker("#28c840", 1.14)
+                        color: floatButton.down ? "#25b33d" : (floatButton.hovered ? "#28c840" : "#4fd764")
+                        scale: floatButton.down ? 0.95 : 1.0
+
+                        Rectangle {
+                            anchors.fill: parent
+                            antialiasing: true
+                            radius: parent.radius
+                            border.width: 0
+                            gradient: Gradient {
+                                GradientStop { position: 0.0; color: "#2fffffff" }
+                                GradientStop { position: 1.0; color: "#00000000" }
+                            }
+                        }
+
+                        Behavior on color { ColorAnimation { duration: 140; easing.type: Easing.OutCubic } }
+                        Behavior on scale { NumberAnimation { duration: 90; easing.type: Easing.OutQuad } }
+                    }
+                }
+
+                ToolButton {
+                    id: maximizeButton
+                    objectName: "maximizeButton"
+                    visible: root.showMaximizeWindowButton
+                    enabled: root.maximizeButtonVisible
+                    width: root.trafficButtonHitSize
+                    height: root.trafficButtonHitSize
+                    hoverEnabled: true
+                    onClicked: root.maximizeButtonClicked()
+
+                    contentItem: Item {
+                        anchors.fill: parent
+                        opacity: maximizeButton.hovered ? 0.82 : 0.0
+
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 6
+                            height: 1
+                            radius: 1
+                            color: "#1c5f31"
+                        }
+                        Rectangle {
+                            anchors.centerIn: parent
+                            width: 1
+                            height: 6
+                            radius: 1
+                            color: "#1c5f31"
+                        }
+
+                        Behavior on opacity { NumberAnimation { duration: 120; easing.type: Easing.OutCubic } }
+                    }
+
+                    background: Rectangle {
+                        implicitWidth: root.trafficButtonSize
+                        implicitHeight: root.trafficButtonSize
+                        anchors.centerIn: parent
+                        antialiasing: true
+                        radius: width / 2
+                        border.width: 0.7
+                        border.color: Qt.darker("#28c840", 1.14)
+                        color: maximizeButton.down ? "#25b33d" : (maximizeButton.hovered ? "#28c840" : "#4fd764")
+                        scale: maximizeButton.down ? 0.95 : 1.0
+
+                        Rectangle {
+                            anchors.fill: parent
+                            antialiasing: true
+                            radius: parent.radius
+                            border.width: 0
+                            gradient: Gradient {
+                                GradientStop { position: 0.0; color: "#2fffffff" }
+                                GradientStop { position: 1.0; color: "#00000000" }
+                            }
+                        }
+
+                        Behavior on color { ColorAnimation { duration: 140; easing.type: Easing.OutCubic } }
+                        Behavior on scale { NumberAnimation { duration: 90; easing.type: Easing.OutQuad } }
+                    }
+                }
+            }
         }
-        btn.onClicked: {
-            root.floatButtonClicked();
+
+        Text {
+            Layout.fillWidth: true
+            Layout.alignment: Qt.AlignVCenter
+            horizontalAlignment: Text.AlignHCenter
+            text: root.title
+            color: DockStyle.titleTextColor
+            font.pixelSize: 13
+            font.bold: true
+            elide: Text.ElideRight
+            verticalAlignment: Text.AlignVCenter
+        }
+
+        Item {
+            Layout.alignment: Qt.AlignVCenter
+            Layout.preferredWidth: leftButtons.Layout.preferredWidth
+            Layout.preferredHeight: leftButtons.Layout.preferredHeight
         }
     }
-    Z.CButton {
-        id: closeButton
-        visible: root.closeButtonEnabled
-        fillWidth: false
-        enabled: root.floatButtonVisible
-        height: root.height - 15
-        width: height
-        iconFull: true
-        source:"/resource/icon/window_close.png"
-        anchors {
-            right: root.right
-            rightMargin: 10
-            verticalCenter: root.verticalCenter
+
+    onTitleBarCppChanged: {
+        if (titleBarCpp) {
+            if (titleBarCpp.redirectMouseEvents)
+                titleBarCpp.redirectMouseEvents(titleBarDragMouseArea)
+            titleBarCpp.titleBarQmlItem = root
         }
-        btn.onClicked: {
-            root.closeButtonClicked();
-        }
+    }
+
+    onCloseButtonClicked: {
+        if (titleBarCpp)
+            titleBarCpp.onCloseClicked()
+    }
+
+    onFloatButtonClicked: {
+        if (titleBarCpp)
+            titleBarCpp.onFloatClicked()
+    }
+
+    onMaximizeButtonClicked: {
+        if (titleBarCpp)
+            titleBarCpp.onMaximizeClicked()
+    }
+
+    onMinimizeButtonClicked: {
+        if (titleBarCpp)
+            titleBarCpp.onMinimizeClicked()
     }
 }

--- a/Client/src/qml/CustomDW/qmldir
+++ b/Client/src/qml/CustomDW/qmldir
@@ -1,0 +1,2 @@
+module CustomDW
+singleton DockStyle 1.0 DockStyle.qml

--- a/Client/src/qml/Field.qml
+++ b/Client/src/qml/Field.qml
@@ -20,6 +20,7 @@ Item {
             id: fieldBar
             width: parent.width
             height: 48
+            currentIndex: 1
 
             TabButton { text: "Origin" }
             TabButton { text: "Filtered B" }

--- a/Client/src/qml/Field.qml
+++ b/Client/src/qml/Field.qml
@@ -1,6 +1,6 @@
-import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import ZSS 1.0 as ZSS
 
 Item {

--- a/Client/src/qml/Field.qml
+++ b/Client/src/qml/Field.qml
@@ -2,6 +2,7 @@ import QtQuick 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import ZSS 1.0 as ZSS
+import "Components" as Components
 
 Item {
     id: root
@@ -32,21 +33,23 @@ Item {
         anchors.fill: parent
         spacing: 0
 
-        TabBar {
-            id: fieldBar
-            width: parent.width
-            height: 48
+        Components.NavView {
+            id: fieldNav
+            width: Math.min(parent.width - 12, cellWidth)
+            height: implicitHeight
+            x: 6
             currentIndex: 1
-
-            TabButton { text: "Origin" }
-            TabButton { text: "Filtered B" }
-            TabButton { text: "Filtered Y" }
+            items: ["Origin", "Filtered Blue", "Filtered Yellow"]
+            panelColor: "#2f2f2f"
+            activeColor: "#1d1d1d"
+            hoverColor: "#3a3a3a"
+            accentColor: "#00a2ff"
         }
 
         Item {
             id: fieldArea
             width: parent.width
-            height: parent.height - fieldBar.height
+            height: parent.height - fieldNav.height
 
             Rectangle {
                 anchors.fill: parent
@@ -58,7 +61,7 @@ Item {
                 ZSS.Field {
                     id: field
                     anchors.fill: parent
-                    type: fieldBar.currentIndex + 1
+                    type: fieldNav.currentIndex + 1
                     draw: true
                     onWidthChanged: interaction.setSize(width, height)
                     onHeightChanged: interaction.setSize(width, height)

--- a/Client/src/qml/Field.qml
+++ b/Client/src/qml/Field.qml
@@ -7,6 +7,22 @@ Item {
     id: root
     anchors.fill: parent
 
+    ZSS.Interaction4Field {
+        id: interaction
+    }
+
+    Timer {
+        id: fpsTimer
+        interval: 1000
+        running: true
+        repeat: true
+        onTriggered: {
+            fps.text = interaction.getFPS().toString()
+                       + "\n" + interaction.getMedusaFPS(0).toString()
+                       + "\n" + interaction.getMedusaFPS(1).toString()
+        }
+    }
+
     Rectangle {
         anchors.fill: parent
         color: "#303030"
@@ -28,6 +44,7 @@ Item {
         }
 
         Item {
+            id: fieldArea
             width: parent.width
             height: parent.height - fieldBar.height
 
@@ -43,6 +60,51 @@ Item {
                     anchors.fill: parent
                     type: fieldBar.currentIndex + 1
                     draw: true
+                    onWidthChanged: interaction.setSize(width, height)
+                    onHeightChanged: interaction.setSize(width, height)
+                    Component.onCompleted: interaction.setSize(width, height)
+                }
+            }
+
+            Text {
+                id: fpsWord
+                text: qsTr("FPS")
+                x: parent.width - 70
+                y: 5
+                color: "white"
+                font.pointSize: 11
+                font.weight: Font.Bold
+            }
+
+            Text {
+                id: fps
+                text: "0\n0\n0"
+                x: parent.width - 30
+                y: 5
+                color: "#0077ff"
+                font.pointSize: 12
+                font.weight: Font.Bold
+            }
+
+            Text {
+                id: positionDisplay
+                color: "white"
+                x: 10
+                y: 5
+                property string strX: "0"
+                property string strY: "0"
+                text: qsTr("( " + strX + " , " + strY + " )")
+                font.pointSize: 12
+                font.weight: Font.Bold
+            }
+
+            MouseArea {
+                anchors.fill: parent
+                hoverEnabled: true
+                acceptedButtons: Qt.NoButton
+                onPositionChanged: {
+                    positionDisplay.strX = interaction.getRealX(mouseX).toString()
+                    positionDisplay.strY = interaction.getRealY(mouseY).toString()
                 }
             }
         }

--- a/Client/src/qml/Field.qml
+++ b/Client/src/qml/Field.qml
@@ -1,22 +1,49 @@
 import QtQuick
+import QtQuick.Controls
+import QtQuick.Layouts
 import ZSS 1.0 as ZSS
 
-Item{
-    property alias type: field.type;
-    property alias draw: field.draw;
-    anchors.fill: parent;
-    ZSS.Field{
-        id: field;
-        type:0;
-        draw:true;
-        anchors.fill: parent;
+Item {
+    id: root
+    anchors.fill: parent
+
+    Rectangle {
+        anchors.fill: parent
+        color: "#303030"
     }
-    onWidthChanged: {
-        console.log("Field.qml width changed", width, height);
-        // field.resize(width, height);
-    }
-    onHeightChanged: {
-        console.log("Field.qml height changed", width, height);
-        // field.resize(width, height);
+
+    Column {
+        anchors.fill: parent
+        spacing: 0
+
+        TabBar {
+            id: fieldBar
+            width: parent.width
+            height: 48
+
+            TabButton { text: "Origin" }
+            TabButton { text: "Filtered B" }
+            TabButton { text: "Filtered Y" }
+        }
+
+        Item {
+            width: parent.width
+            height: parent.height - fieldBar.height
+
+            Rectangle {
+                anchors.fill: parent
+                border.color: "#555"
+                border.width: 1
+                color: "transparent"
+
+                // Keep only one Field instance and switch its type by tab.
+                ZSS.Field {
+                    id: field
+                    anchors.fill: parent
+                    type: fieldBar.currentIndex + 1
+                    draw: true
+                }
+            }
+        }
     }
 }

--- a/Client/src/qml/Settings.qml
+++ b/Client/src/qml/Settings.qml
@@ -1,157 +1,264 @@
-import QtQuick 2.7
+import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import ZSS 1.0 as ZSS
-Item{
-    ZSS.ParamModel{
-        id:paramModel;
+
+Item {
+    id: root
+
+    readonly property int roleSettingName: 257
+    readonly property int roleSettingType: 258
+    readonly property int roleSettingValue: 259
+
+    ZSS.ParamModel {
+        id: paramModel
     }
-    Shortcut{
+
+    function groupIndexAt(row) {
+        return paramModel.index(row, 0)
+    }
+
+    function childIndexAt(row) {
+        if (groupList.currentIndex < 0)
+            return null
+        return paramModel.index(row, 0, groupIndexAt(groupList.currentIndex))
+    }
+
+    function childDataAt(row, role) {
+        const idx = childIndexAt(row)
+        if (!idx)
+            return ""
+        return paramModel.data(idx, role)
+    }
+
+    function childCount() {
+        if (groupList.currentIndex < 0)
+            return 0
+        return paramModel.rowCount(groupIndexAt(groupList.currentIndex))
+    }
+
+    Shortcut {
         sequence: "r"
         onActivated: {
-            paramModel.reload();
+            paramModel.reload()
+            if (groupList.currentIndex < 0 && paramModel.rowCount() > 0)
+                groupList.currentIndex = 0
         }
     }
-    TreeView{
-        id:paramTree
+
+    Component.onCompleted: {
+        if (paramModel.rowCount() > 0)
+            groupList.currentIndex = 0
+    }
+
+    RowLayout {
         anchors.fill: parent
-        horizontalScrollBarPolicy: Qt.ScrollBarAlwaysOff
-        verticalScrollBarPolicy: Qt.ScrollBarAlwaysOff
-        TableViewColumn {
-            title: "Name"
-            role: "settingName"
-            width:parent.width*0.4;
-            delegate:normalTextDelegate;
-        }
-        TableViewColumn {
-            title: "Type"
-            role: "settingType"
-            width:parent.width*0.2;
-            delegate:normalTextDelegate;
-        }
-        TableViewColumn {
-            title: "Value"
-            role: "settingValue"
-            width:parent.width*0.4;
-            delegate:stringDelegate;
+        spacing: 0
+
+        Rectangle {
+            Layout.fillHeight: true
+            Layout.preferredWidth: parent.width * 0.28
+            color: "#404040"
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 0
+
+                Rectangle {
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 40
+                    color: "#333333"
+
+                    Text {
+                        anchors.verticalCenter: parent.verticalCenter
+                        anchors.left: parent.left
+                        anchors.leftMargin: 12
+                        text: "Group"
+                        color: "#ffffff"
+                        font.pixelSize: 15
+                    }
+                }
+
+                ListView {
+                    id: groupList
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    clip: true
+                    model: paramModel
+
+                    delegate: Rectangle {
+                        width: groupList.width
+                        height: 34
+                        color: ListView.isCurrentItem ? "#2d6a9f" : "#404040"
+
+                        Text {
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.left: parent.left
+                            anchors.leftMargin: 12
+                            text: settingName
+                            color: "#e8e8e8"
+                            font.pixelSize: 14
+                            elide: Text.ElideRight
+                            width: parent.width - 20
+                        }
+
+                        MouseArea {
+                            anchors.fill: parent
+                            onClicked: groupList.currentIndex = index
+                        }
+                    }
+                }
+            }
         }
 
-        style: TreeViewStyle {
-            backgroundColor: "#484848";
-            alternateBackgroundColor:"#404040";
-            textColor:"#ccc";
-//            branchDelegate: Rectangle {
-//                width: 12; height: 12
-//                color: styleData.isExpanded ? "#ccc" : "#aaa"
-//                radius: width/2
-//            }
-//            frame: Rectangle {border {color: "blue"}}
-            headerDelegate: Rectangle {
-                height: headerItem.implicitHeight*1.4
-                width: headerItem.implicitWidth
-                color: "#333"
-                Text {
-                    id: headerItem
-                    anchors.fill: parent
-                    verticalAlignment: Text.AlignVCenter
-                    horizontalAlignment: styleData.textAlignment
-                    anchors.leftMargin: 12
-                    text: styleData.value
-                    elide: Text.ElideRight
-                    color: "#fff";
-                    renderType: Text.NativeRendering
-                    font.pixelSize: 16;
-                    font.family: "Arial";
-                }
+        Rectangle {
+            Layout.fillWidth: true
+            Layout.fillHeight: true
+            color: "#484848"
+
+            ColumnLayout {
+                anchors.fill: parent
+                spacing: 0
+
                 Rectangle {
-                    anchors.right: parent.right
-                    anchors.top: parent.top
-                    anchors.bottom: parent.bottom
-                    anchors.bottomMargin: 1
-                    anchors.topMargin: 1
-                    width: 1
-                    color: "#777"
+                    Layout.fillWidth: true
+                    Layout.preferredHeight: 40
+                    color: "#333333"
+
+                    RowLayout {
+                        anchors.fill: parent
+                        spacing: 0
+
+                        Text {
+                            Layout.preferredWidth: parent.width * 0.4
+                            Layout.fillHeight: true
+                            leftPadding: 12
+                            verticalAlignment: Text.AlignVCenter
+                            text: "Name"
+                            color: "#ffffff"
+                            font.pixelSize: 15
+                        }
+                        Text {
+                            Layout.preferredWidth: parent.width * 0.2
+                            Layout.fillHeight: true
+                            leftPadding: 12
+                            verticalAlignment: Text.AlignVCenter
+                            text: "Type"
+                            color: "#ffffff"
+                            font.pixelSize: 15
+                        }
+                        Text {
+                            Layout.preferredWidth: parent.width * 0.4
+                            Layout.fillHeight: true
+                            leftPadding: 12
+                            verticalAlignment: Text.AlignVCenter
+                            text: "Value"
+                            color: "#ffffff"
+                            font.pixelSize: 15
+                        }
+                    }
                 }
-                Rectangle {
-                    anchors.right: parent.right
-                    anchors.left: parent.left
-                    anchors.top: parent.top
-                    anchors.leftMargin: 1
-                    anchors.rightMargin: 1
-                    height:1
-                    color: "#777"
+
+                ListView {
+                    id: valueList
+                    Layout.fillWidth: true
+                    Layout.fillHeight: true
+                    clip: true
+                    model: childCount()
+
+                    delegate: Rectangle {
+                        required property int index
+
+                        width: valueList.width
+                        height: 34
+                        color: index % 2 === 0 ? "#484848" : "#404040"
+
+                        RowLayout {
+                            anchors.fill: parent
+                            spacing: 0
+
+                            Text {
+                                Layout.preferredWidth: parent.width * 0.4
+                                Layout.fillHeight: true
+                                leftPadding: 12
+                                verticalAlignment: Text.AlignVCenter
+                                text: root.childDataAt(index, root.roleSettingName)
+                                color: "#d6d6d6"
+                                elide: Text.ElideRight
+                                font.pixelSize: 14
+                            }
+
+                            Text {
+                                Layout.preferredWidth: parent.width * 0.2
+                                Layout.fillHeight: true
+                                leftPadding: 12
+                                verticalAlignment: Text.AlignVCenter
+                                text: root.childDataAt(index, root.roleSettingType)
+                                color: "#d6d6d6"
+                                elide: Text.ElideRight
+                                font.pixelSize: 14
+                            }
+
+                            Loader {
+                                id: editorLoader
+                                property int rowIndex: index
+                                Layout.preferredWidth: parent.width * 0.4
+                                Layout.fillHeight: true
+                                sourceComponent: root.childDataAt(index, root.roleSettingType) === "Bool" ? boolEditor : textEditor
+                                onLoaded: {
+                                    if (item)
+                                        item.rowIndex = rowIndex
+                                }
+                                onRowIndexChanged: {
+                                    if (item)
+                                        item.rowIndex = rowIndex
+                                }
+                            }
+                        }
+                    }
                 }
-            }
-            rowDelegate:Rectangle{
-                height: 30;
-                width:parent.width;
-                property color selectedColor: control.activeFocus ? "#07c" : "#999"
-                color: !styleData.alternate ? alternateBackgroundColor : backgroundColor
             }
         }
-        model:paramModel;
     }
+
     Component {
-        id: stringDelegate
-        Loader{
-            property var styleData : parent.styleData;
-            property string type : paramModel.getType(styleData.index);
-            sourceComponent: styleData.hasChildren ? normalTextDelegate : (type == "Bool" ? boolDelegate : notBoolDelegate)
-        }
-    }
-    Component{
-        id:notBoolDelegate
-        Rectangle{
-            property var styleData : parent.styleData;
-            color: input.activeFocus  ? "#ccc" : "transparent";
-            height:30;
-            TextInput {
-                id:input;
-                anchors.fill: parent;
-                text: styleData.value
-                color:activeFocus?"#222":styleData.textColor;
-                horizontalAlignment: styleData.textAlignment
-                font.pixelSize: 16;
-                font.family:"Arial";
-                leftPadding: 12;
-                verticalAlignment: Text.AlignVCenter
-                //validator:RegExpValidator { regExp: /^(-?)(0|([1-9][0-9]*))(\.[0-9]+)?$/ }
-                onAccepted:{
-                    if(paramModel.setData(styleData.index,text))
-                        focus = false;
-                }
+        id: textEditor
+        TextField {
+            property int rowIndex: -1
+
+            text: root.childDataAt(rowIndex, root.roleSettingValue)
+            color: "#e8e8e8"
+            leftPadding: 12
+            background: Rectangle {
+                color: parent.activeFocus ? "#5a5a5a" : "transparent"
+                border.color: parent.activeFocus ? "#8aaed1" : "transparent"
+                border.width: 1
+            }
+            onAccepted: {
+                const idx = root.childIndexAt(rowIndex)
+                if (idx)
+                    paramModel.setData(idx, text)
+            }
+            onEditingFinished: {
+                const idx = root.childIndexAt(rowIndex)
+                if (idx)
+                    paramModel.setData(idx, text)
             }
         }
     }
-    Component{
-        id:boolDelegate;
-        Rectangle{
-            property var styleData : parent.styleData;
-            color: "transparent";
-            height:30;
-            width:parent.width;
-            CheckBox{
-                id:input;
-                height:30;
-                x:12;
-                checked: styleData.value === "true"
-                onClicked: paramModel.setData(styleData.index,checked ? "true" : "false")
+
+    Component {
+        id: boolEditor
+        CheckBox {
+            property int rowIndex: -1
+
+            leftPadding: 12
+            checked: root.childDataAt(rowIndex, root.roleSettingValue) === "true"
+            onClicked: {
+                const idx = root.childIndexAt(rowIndex)
+                if (idx)
+                    paramModel.setData(idx, checked ? "true" : "false")
             }
         }
-    }
-    Component{
-        id: normalTextDelegate
-//        Rectangle{
-//            height:30;
-//            color: "transparent"
-            Text {
-                lineHeight:30;
-                leftPadding:12;
-                anchors.verticalCenter: parent.verticalCenter
-                color: styleData.textColor
-                elide: styleData.elideMode
-                text: styleData.value
-                font.pixelSize: 15
-            }
-//        }
     }
 }

--- a/Client/src/qml/Settings.qml
+++ b/Client/src/qml/Settings.qml
@@ -1,6 +1,6 @@
-import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import ZSS 1.0 as ZSS
 
 Item {

--- a/Client/src/qml/Settings.qml
+++ b/Client/src/qml/Settings.qml
@@ -168,9 +168,10 @@ Item {
 
                     delegate: Rectangle {
                         required property int index
+                        readonly property bool isBoolType: root.childDataAt(index, root.roleSettingType) === "Bool"
 
                         width: valueList.width
-                        height: 34
+                        height: isBoolType ? 34 : 42
                         color: index % 2 === 0 ? "#484848" : "#404040"
 
                         RowLayout {
@@ -204,7 +205,7 @@ Item {
                                 property int rowIndex: index
                                 Layout.preferredWidth: parent.width * 0.4
                                 Layout.fillHeight: true
-                                sourceComponent: root.childDataAt(index, root.roleSettingType) === "Bool" ? boolEditor : textEditor
+                                sourceComponent: isBoolType ? boolEditor : textEditor
                                 onLoaded: {
                                     if (item)
                                         item.rowIndex = rowIndex
@@ -226,6 +227,10 @@ Item {
         TextField {
             property int rowIndex: -1
 
+            verticalAlignment: TextInput.AlignVCenter
+            font.pixelSize: 14
+            topPadding: 0
+            bottomPadding: 0
             text: root.childDataAt(rowIndex, root.roleSettingValue)
             color: "#e8e8e8"
             leftPadding: 12

--- a/Client/src/qml/ZGroupBox.qml
+++ b/Client/src/qml/ZGroupBox.qml
@@ -1,5 +1,5 @@
-import QtQuick
-import QtQuick.Controls
+import QtQuick 2.15
+import QtQuick.Controls 2.15
 GroupBox{
     title: qsTr("No Title")
     width:parent.itemWidth;

--- a/Client/src/qml/ZSuggestComboBox.qml
+++ b/Client/src/qml/ZSuggestComboBox.qml
@@ -1,0 +1,268 @@
+import QtQuick 2.10
+import QtQuick.Controls 2.15
+
+Item {
+    id: root
+
+    property var model: []
+    property int currentIndex: -1
+    readonly property string currentText: (currentIndex >= 0 && currentIndex < model.length) ? String(model[currentIndex]) : ""
+    property string placeholderText: "Type to search"
+    property int marqueePauseDuration: 1200
+    property int marqueeEndPauseDuration: 800
+    property int marqueeReturnDuration: 250
+    property int marqueeSpeedFactor: 12
+    property int highlightedFilteredIndex: -1
+
+    signal activated(int index)
+
+    implicitWidth: parent.buttonWidth || parent.itemWidth || 20
+    implicitHeight: parent.buttonHeight || parent.itemHeight || 40
+
+    function updateTextByCurrentIndex() {
+        if (currentIndex >= 0 && currentIndex < model.length) {
+            input.text = String(model[currentIndex])
+        } else {
+            input.text = ""
+            currentIndex = -1
+        }
+    }
+
+    function refreshFilteredModel() {
+        filteredModel.clear()
+        var keyword = input.text.toLowerCase()
+        if (!input.activeFocus || keyword.length === 0) {
+            highlightedFilteredIndex = -1
+            popup.close()
+            return
+        }
+        for (var i = 0; i < model.length; ++i) {
+            var text = String(model[i])
+            if (text.toLowerCase().indexOf(keyword) !== -1) {
+                filteredModel.append({"text": text, "sourceIndex": i})
+            }
+        }
+        if (filteredModel.count > 0) {
+            highlightedFilteredIndex = 0
+            popup.open()
+        } else {
+            highlightedFilteredIndex = -1
+            popup.close()
+        }
+    }
+
+    function moveHighlight(step) {
+        if (filteredModel.count <= 0) return
+        if (!popup.visible) popup.open()
+        if (highlightedFilteredIndex < 0) {
+            highlightedFilteredIndex = 0
+            return
+        }
+        highlightedFilteredIndex = (highlightedFilteredIndex + step + filteredModel.count) % filteredModel.count
+    }
+
+    function confirmSelection() {
+        if (filteredModel.count <= 0) return
+        var idx = highlightedFilteredIndex >= 0 ? highlightedFilteredIndex : 0
+        var item = filteredModel.get(idx)
+        root.selectItem(item.sourceIndex, item.text)
+    }
+
+    function selectItem(sourceIndex, text) {
+        currentIndex = sourceIndex
+        input.text = text
+        popup.close()
+        input.focus = false
+        activated(sourceIndex)
+    }
+
+    onModelChanged: {
+        if (currentIndex >= model.length) {
+            currentIndex = model.length > 0 ? 0 : -1
+        }
+        updateTextByCurrentIndex()
+        refreshFilteredModel()
+    }
+
+    onCurrentIndexChanged: {
+        updateTextByCurrentIndex()
+    }
+
+    TextField {
+        id: input
+        anchors.fill: parent
+        placeholderText: root.placeholderText
+        topPadding: 0
+        bottomPadding: 0
+        leftPadding: 8
+        rightPadding: 8
+        verticalAlignment: TextInput.AlignVCenter
+        color: marqueeOverlay.visible ? "transparent" : "#ffffff"
+        placeholderTextColor: "#ffffff"
+        selectedTextColor: "#ffffff"
+        selectionColor: "#279BE6"
+        background: Rectangle {
+            radius: 2
+            color: input.enabled ? "#3a3a3a" : "#2f2f2f"
+            border.width: 0
+            border.color: "transparent"
+        }
+
+        Keys.onDownPressed: function(event) {
+            root.moveHighlight(1)
+            event.accepted = true
+        }
+
+        Keys.onUpPressed: function(event) {
+            root.moveHighlight(-1)
+            event.accepted = true
+        }
+
+        Keys.onReturnPressed: function(event) {
+            root.confirmSelection()
+            event.accepted = true
+        }
+
+        Keys.onEnterPressed: function(event) {
+            root.confirmSelection()
+            event.accepted = true
+        }
+
+        onTextEdited: {
+            refreshFilteredModel()
+        }
+
+        onActiveFocusChanged: {
+            if (!activeFocus) {
+                popup.close()
+            } else {
+                refreshFilteredModel()
+            }
+        }
+    }
+
+    Rectangle {
+        id: marqueeOverlay
+        anchors {
+            left: input.left
+            right: input.right
+            top: input.top
+            bottom: input.bottom
+            leftMargin: input.leftPadding
+            rightMargin: input.rightPadding
+            topMargin: 1
+            bottomMargin: 1
+        }
+        visible: !input.activeFocus
+                 && input.text.length > 0
+                 && marqueeText.implicitWidth > (width - 4)
+        clip: true
+        color: "transparent"
+
+        Text {
+            id: marqueeText
+            text: input.text
+            color: "#ffffff"
+            font: input.font
+            y: (parent.height - implicitHeight) / 2
+            x: 0
+
+            SequentialAnimation on x {
+                running: marqueeOverlay.visible
+                loops: Animation.Infinite
+
+                PauseAnimation { duration: root.marqueePauseDuration }
+
+                NumberAnimation {
+                    to: -(marqueeText.implicitWidth - marqueeOverlay.width + 8)
+                    duration: Math.max(root.marqueePauseDuration,
+                                       (marqueeText.implicitWidth - marqueeOverlay.width + 8) * root.marqueeSpeedFactor)
+                    easing.type: Easing.Linear
+                }
+
+                PauseAnimation { duration: root.marqueeEndPauseDuration }
+
+                NumberAnimation {
+                    to: 0
+                    duration: root.marqueeReturnDuration
+                    easing.type: Easing.InOutQuad
+                }
+            }
+        }
+
+        MouseArea {
+            anchors.fill: parent
+            cursorShape: Qt.IBeamCursor
+            onClicked: input.forceActiveFocus()
+        }
+    }
+
+    ListModel {
+        id: filteredModel
+    }
+
+    Popup {
+        id: popup
+        width: root.width
+        y: root.height
+        padding: 0
+        focus: false
+
+        contentItem: ListView {
+            id: listView
+            model: filteredModel
+            clip: true
+            implicitHeight: Math.min(contentHeight, 240)
+            currentIndex: root.highlightedFilteredIndex
+
+            delegate: ItemDelegate {
+                width: listView.width
+                highlighted: index === root.highlightedFilteredIndex
+                contentItem: Item {
+                    clip: true
+
+                    Text {
+                        id: delegateText
+                        text: model.text
+                        color: "#ffffff"
+                        font: input.font
+                        y: (parent.height - implicitHeight) / 2
+                        x: 0
+
+                        SequentialAnimation on x {
+                            running: marqueeMask.visible
+                            loops: Animation.Infinite
+
+                            PauseAnimation { duration: root.marqueePauseDuration }
+
+                            NumberAnimation {
+                                to: -(delegateText.implicitWidth - marqueeMask.width + 8)
+                                duration: Math.max(root.marqueePauseDuration,
+                                                   (delegateText.implicitWidth - marqueeMask.width + 8) * root.marqueeSpeedFactor)
+                                easing.type: Easing.Linear
+                            }
+
+                            PauseAnimation { duration: root.marqueeEndPauseDuration }
+
+                            NumberAnimation {
+                                to: 0
+                                duration: root.marqueeReturnDuration
+                                easing.type: Easing.InOutQuad
+                            }
+                        }
+                    }
+
+                    Item {
+                        id: marqueeMask
+                        anchors.fill: parent
+                        visible: delegateText.implicitWidth > width
+                    }
+                }
+                onClicked: {
+                    root.highlightedFilteredIndex = index
+                    root.selectItem(model.sourceIndex, model.text)
+                }
+            }
+        }
+    }
+}

--- a/Client/src/qml/main.qml
+++ b/Client/src/qml/main.qml
@@ -1,7 +1,7 @@
 import QtQuick 2.7
 import QtQuick.Window 2.3
-import QtQuick.Controls
-import QtQuick.Layouts
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import QtQml 2.2
 import ZSS 1.0 as ZSS
 Window {

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -3,12 +3,23 @@ import QtQuick.Window 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import com.kdab.dockwidgets 2.0 as KDDW
+import CustomDW 1.0
 
 ApplicationWindow {
     visible: true
     width: screen.width;
     height: screen.height - 100;
     title: qsTr("@rocosCli")
+
+    // qss-like style string for KDDockWidgets custom skin.
+    Component.onCompleted: {
+        DockStyle.styleSheet = "title-bg:#18202b; title-border:#2f3e52; title-fg:#eaf1ff;"
+                              + "frame-bg:#0f151f; frame-border:#2f3e52; frame-radius:10;"
+                              + "tab-bg:#141e2b; tab-border:#2c3a4f; tab-fg:#8ea3c0;"
+                              + "tab-active-bg:#2c8cff; tab-active-fg:#ffffff;"
+                              + "btn-hover-bg:#2f3f56; btn-pressed-bg:#213249; btn-fg:#eaf1ff;"
+                              + "title-height:38; tab-height:34; btn-size:22"
+    }
 
     KDDW.DockingArea {
         id: root

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -35,10 +35,7 @@ ApplicationWindow {
         }
 
         Component.onCompleted: {
-            addDockWidget(centralDock,
-                          KDDW.KDDockWidgets.Location_OnLeft,
-                          null,
-                          Qt.size(root.width * 0.8, root.height))
+            addDockWidgetAsTab(centralDock)
             addDockWidget(controlBoardDock,
                           KDDW.KDDockWidgets.Location_OnRight,
                           centralDock,

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -32,17 +32,23 @@ ApplicationWindow {
         }
 
         KDDW.DockWidget {
-            id: dock5
-            uniqueName: "dock5"
-            Rectangle {
-                id: guest
-                color: "#2E8BC0"
+            id: controlBoardDock
+            uniqueName: "controlBoardDock"
+            title: "ControlBoard"
+            ControlBoard {
                 anchors.fill: parent
             }
         }
+
         Component.onCompleted: {
-            addDockWidget(centralDock, KDDW.KDDockWidgets.Location_OnTop)
-            addDockWidget(dock5, KDDW.KDDockWidgets.Location_OnBottom);
+            addDockWidget(centralDock,
+                          KDDW.KDDockWidgets.Location_OnLeft,
+                          null,
+                          Qt.size(root.width * 0.8, root.height))
+            addDockWidget(controlBoardDock,
+                          KDDW.KDDockWidgets.Location_OnRight,
+                          centralDock,
+                          Qt.size(root.width * 0.2, root.height))
         }
     }
 

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -1,13 +1,7 @@
 import QtQuick
 import QtQuick.Controls
+import QtQuick.Layouts
 import com.kdab.dockwidgets 2.0 as KDDW
-import ZSS 1.0 as ZSS
-
-// ZSS.Field{
-//     type:0;
-//     draw:true;
-//     anchors.fill: parent;
-// }
 
 ApplicationWindow {
     visible: true

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -19,10 +19,17 @@ ApplicationWindow {
         id: root
         anchors.fill: parent
 
-        persistentCentralItemFileName: ":/src/qml/Field.qml"
-        options: KDDW.KDDockWidgets.MainWindowOption_HasCentralWidget
-
+        options: KDDW.KDDockWidgets.MainWindowOption_HasCentralFrame
         uniqueName: "MainLayout-1"
+
+        KDDW.DockWidget {
+            id: centralDock
+            uniqueName: "centralField"
+            title: "Field"
+            Field {
+                anchors.fill: parent
+            }
+        }
 
         KDDW.DockWidget {
             id: dock5
@@ -34,6 +41,7 @@ ApplicationWindow {
             }
         }
         Component.onCompleted: {
+            addDockWidget(centralDock, KDDW.KDDockWidgets.Location_OnTop)
             addDockWidget(dock5, KDDW.KDDockWidgets.Location_OnBottom);
         }
     }

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -1,6 +1,6 @@
-import QtQuick
-import QtQuick.Controls
-import QtQuick.Layouts
+import QtQuick 2.15
+import QtQuick.Controls 2.15
+import QtQuick.Layouts 1.15
 import com.kdab.dockwidgets 2.0 as KDDW
 
 ApplicationWindow {

--- a/Client/src/qml/main_test.qml
+++ b/Client/src/qml/main_test.qml
@@ -1,12 +1,13 @@
 import QtQuick 2.15
+import QtQuick.Window 2.15
 import QtQuick.Controls 2.15
 import QtQuick.Layouts 1.15
 import com.kdab.dockwidgets 2.0 as KDDW
 
 ApplicationWindow {
     visible: true
-    width: 1000
-    height: 800
+    width: screen.width;
+    height: screen.height - 100;
     title: qsTr("@rocosCli")
 
     KDDW.DockingArea {

--- a/Client/src/rec_recorder.cpp
+++ b/Client/src/rec_recorder.cpp
@@ -4,6 +4,7 @@
 #include "field.h"
 #include <QDateTime>
 #include <QDataStream>
+#include <QDir>
 #include <QFile>
 #include <QFileInfo>
 #include "parammanager.h"
@@ -20,22 +21,34 @@ QString filename;
 //QTime timer;
 }
 RecRecorder::RecRecorder() {
+    isRun = false;
+    recIO = nullptr;
 }
 void RecRecorder::init() {
     isRun = true;
 //        qDebug() << "I AM RUNNING";
     QDateTime datetime;
 //        qDebug() << datetime.currentDateTime().toString("yyyy-MM-dd-HH-mm-ss");
+    QDir().mkpath("LOG");
     filename = QString("LOG/Rec").append(datetime.currentDateTime().toString("yyyy-MM-dd-HH-mm-ss")).append(".log");
 //    recordFile = new QFile(filename);
     recordFile.setFileName(filename);
-    recordFile.open(QIODevice::WriteOnly | QIODevice::Append);
+    if (!recordFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
+        isRun = false;
+        recIO = nullptr;
+    }
 //    recordFile->open(QIODevice::WriteOnly | QIODevice::Append);
 }
 
 void RecRecorder::store() {
     if (isRun) {
-        recordFile.open(QIODevice::WriteOnly | QIODevice::Append);
+        if (filename.isEmpty()) {
+            return;
+        }
+        if (!recordFile.isOpen() && !recordFile.open(QIODevice::WriteOnly | QIODevice::Append)) {
+            recIO = nullptr;
+            return;
+        }
         recIO = &recordFile;
         //    Field::repaintLock();
         //    qDebug() << "I AM FUCKING RUNNING";
@@ -120,6 +133,12 @@ void RecRecorder::store() {
 void RecRecorder::stop() {
     isRun = false;
     recIO = nullptr;
+    if (recordFile.isOpen()) {
+        recordFile.close();
+    }
+    if (filename.isEmpty()) {
+        return;
+    }
     QFileInfo afterFile(filename);
     if (afterFile.size() < 1) {
 //        QFile emptyFile(filename);

--- a/Client/src/rec_slider.h
+++ b/Client/src/rec_slider.h
@@ -3,6 +3,7 @@
 
 #include <QObject>
 #include <QQmlEngine>
+#include <QJSEngine>
 #include "zos/utils/singleton.h"
 #include "rec_player.h"
 
@@ -17,10 +18,9 @@ class rec_slider: public QObject
     Q_PROPERTY(double stepSize READ rstepSize WRITE setstepSize NOTIFY stepSizechanged)
 public:
     static QObject* instance(QQmlEngine* engine = nullptr, QJSEngine* scriptEngine = nullptr){
-        Q_UNUSED(engine)
-        Q_UNUSED(scriptEngine)
-        static rec_slider* instance = new rec_slider();
-        return instance;
+        QObject *parent = engine ? static_cast<QObject *>(engine)
+                                 : static_cast<QObject *>(scriptEngine);
+        return new rec_slider(parent);
     }
     explicit rec_slider(QObject* parent = nullptr);
     Q_INVOKABLE QString maxTime = "00:00.000";

--- a/Core/CMakeLists.txt
+++ b/Core/CMakeLists.txt
@@ -34,6 +34,17 @@ find_package(fmt REQUIRED)
 list(APPEND incs ${fmt_INCLUDE_DIRS})
 list(APPEND libs fmt::fmt)
 
+## yaml-cpp
+find_package(yaml-cpp REQUIRED)
+if (TARGET yaml-cpp::yaml-cpp)
+    list(APPEND libs yaml-cpp::yaml-cpp)
+elseif (TARGET yaml-cpp)
+    list(APPEND libs yaml-cpp)
+else()
+    list(APPEND incs ${YAML_CPP_INCLUDE_DIRS})
+    list(APPEND libs ${YAML_CPP_LIBRARIES})
+endif()
+
 set(PROTO_LIST
     grSim_Commands
     grSimMessage

--- a/ZBin/tools/scan_tool
+++ b/ZBin/tools/scan_tool
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
-import os, re
+import os
+import re
 
 # get all tactic package name from pack_path and ignore package name from ignore_file_path
 def get_tactic_packages(pack_path,ignore_file_path):
@@ -28,50 +29,110 @@ def get_all_files(dir):
     files.sort()
     return files
 
+
+def extract_play_name(lua_file_path):
+    # Match lines like: name = "TestRun", (comma optional)
+    pattern = re.compile(r'^\s*name\s*=\s*["\']([^"\']+)["\']\s*,?\s*$')
+    with open(lua_file_path, "r", encoding="utf-8", errors="ignore") as f:
+        for raw_line in f:
+            line = raw_line.split("--", 1)[0].strip()
+            if not line:
+                continue
+            match = pattern.match(line)
+            if match:
+                return match.group(1)
+    return None
+
+
+def scan_play_scripts(play_root, output_mode):
+    if not os.path.isdir(play_root):
+        return []
+
+    results = []
+    seen = set()
+    for root, _, files in os.walk(play_root):
+        for file_name in sorted(files):
+            if not file_name.endswith(".lua"):
+                continue
+            file_path = os.path.join(root, file_name)
+            play_name = extract_play_name(file_path)
+            if not play_name:
+                continue
+
+            value = play_name if output_mode == "playname" else file_path
+            if value in seen:
+                continue
+            seen.add(value)
+            results.append(value)
+
+    return results
+
+
+def scan_core_scripts(core_root, tactic_names, output_mode):
+    results = []
+    seen = set()
+
+    for tactic_name in tactic_names:
+        tactic_dir = os.path.join(core_root, tactic_name, "play")
+        if not os.path.isdir(tactic_dir):
+            continue
+
+        for root, _, files in os.walk(tactic_dir):
+            for file_name in sorted(files):
+                if not file_name.endswith(".lua"):
+                    continue
+                file_path = os.path.join(root, file_name)
+                play_name = extract_play_name(file_path)
+                if not play_name:
+                    continue
+
+                value = play_name if output_mode == "playname" else file_path
+                if value in seen:
+                    continue
+                seen.add(value)
+                results.append(value)
+
+    return results
+
+
+def merge_unique(*groups):
+    merged = []
+    seen = set()
+    for group in groups:
+        for item in group:
+            if item in seen:
+                continue
+            seen.add(item)
+            merged.append(item)
+    return merged
+
 if __name__ == '__main__':
     RELATIVE_PATH = "../../Core/"
+    RELATIVE_PLAY_PATH = "../lua_scripts/play"
     # get current file path
     current_path = os.path.dirname(os.path.abspath(__file__))
+    play_path = os.path.normpath(os.path.join(current_path, RELATIVE_PLAY_PATH))
     tactic_ignore_packages_name_file_path = os.path.join(current_path, "../tactic_ignore_packages.txt")
     tactic_name_list = get_tactic_packages(os.path.join(current_path, RELATIVE_PATH), tactic_ignore_packages_name_file_path)
     tactic_path = os.path.normpath(os.path.join(current_path, RELATIVE_PATH))
 
     import sys
+    if len(sys.argv) < 2:
+        raise SystemExit(0)
+
     if sys.argv[1] == 'tactic_dir':
         for tactic_name in tactic_name_list:
             print(os.path.join(tactic_path, tactic_name))
     if sys.argv[1] == "scripts":
-        for tactic_name in tactic_name_list:
-            tactic_dir = os.path.join(tactic_path, tactic_name, "play")
-            if not os.path.exists(tactic_dir):
-                # print("tactic package {} not exists".format(tactic_dir))
-                continue
-            # get all file name in tactic package
-            files = get_all_files(tactic_dir)
-            # print("tactic package {} has {} files".format(tactic_name, len(files)))
-            for file in files:
-                # check if file is .lua file
-                if not file.endswith(".lua"):
-                    continue
-                # get file content and get 'name = "TestName"' line using regex
-                file_path = os.path.join(tactic_dir, file)
-                with open(file_path, "r") as f:
-                    content = f.read().split('\n')
-                    for line in content:
-                        line = line.replace(' ','')
-                        if "name" in line and line.startswith("name=") and line.endswith(","):
-                            # get name value in "" or ''
-                            name = re.findall(r'name=(?:"|\')(.*?)(?:"|\')', line)
-                            if len(name) == 0:
-                                continue
-                            if len(sys.argv) <= 2 or sys.argv[2] == "playname":
-                                print(name[0])
-                            elif sys.argv[2] == "filename":
-                                print(file_path)
-                            break
+        output_mode = "playname" if len(sys.argv) <= 2 else sys.argv[2]
+        if output_mode not in {"playname", "filename"}:
+            output_mode = "playname"
 
-                # print("{}\t{}".format(tactic_name,file))
-                # print(file)
+        core_results = scan_core_scripts(tactic_path, tactic_name_list, output_mode)
+        play_results = scan_play_scripts(play_path, output_mode)
+
+        for item in merge_unique(core_results, play_results):
+            print(item)
 
     if sys.argv[1] == "ref_configs":
         for tactic_name in tactic_name_list:

--- a/share/zos/socket.h
+++ b/share/zos/socket.h
@@ -24,6 +24,11 @@ public:
             _callback = std::bind(f,std::placeholders::_1,std::placeholders::_2);
         }
         boost::system::error_code ec;
+        _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true), ec);
+        if(ec.value() != 0){
+            std::cerr << fmt::format("get error11 {}:{}",ec.value(),ec.message()) << std::endl;
+            return false;
+        }
         _socket.bind(_listen_ep,ec);
         if(ec.value() != 0){
             std::cerr << fmt::format("get error11 {}:{}",ec.value(),ec.message()) << std::endl;
@@ -54,6 +59,11 @@ public:
     }
     bool try_bind(){
         boost::system::error_code ec;
+        _socket.set_option(boost::asio::ip::udp::socket::reuse_address(true), ec);
+        if(ec.value() != 0){
+            std::cerr << fmt::format("get error {}:{}",ec.value(),ec.message()) << std::endl;
+            return false;
+        }
         _socket.bind(_listen_ep,ec);
         if(ec.value() != 0){
             std::cerr << fmt::format("get error {}:{}",ec.value(),ec.message()) << std::endl;

--- a/share/zos/socketplugin.h
+++ b/share/zos/socketplugin.h
@@ -11,13 +11,19 @@ class Plugin{
 public:
     Plugin(){};
     Plugin(const char* multicast_address){
-        _socket.join_multicast(zos::udp::address::from_string(multicast_address));
+        if(multicast_address){
+            _socket.join_multicast(zos::udp::address::from_string(multicast_address));
+        }
     }
     Plugin(int port,const zos::udp::__callback_type& f={}):Plugin(zos::udp::endpoint(zos::udp::address::from_string("0.0.0.0"),port),nullptr,f){}
     Plugin(const zos::udp::endpoint& ep,const zos::udp::__callback_type& f = {}):Plugin(ep,nullptr,f){}
     Plugin(const zos::udp::endpoint& ep,const char* multicast_address,const zos::udp::__callback_type& f = {}){
-        _socket.bind(ep,f);
-        _socket.join_multicast(zos::udp::address::from_string(multicast_address));
+        if(!_socket.bind(ep,f)){
+            return;
+        }
+        if(multicast_address){
+            _socket.join_multicast(zos::udp::address::from_string(multicast_address));
+        }
     }
     void sendData(const T& t,const zos::udp::endpoint& ep){
         static zos::Data data;

--- a/share/zos/utils/singleton.h
+++ b/share/zos/utils/singleton.h
@@ -9,6 +9,9 @@ class Singleton{
 public:
     template<typename... Ts>
     static T* instance(Ts... args);
+    // Backward compatibility for legacy code paths that still call Instance().
+    template<typename... Ts>
+    static T* Instance(Ts... args){ return instance(args...); }
     template<typename... Ts>
     static T* GetInstance(Ts... args){ return instance(args...); }
     template<typename... Ts>


### PR DESCRIPTION
1. KDockWeight两个组件，一个是field，一个是controlboard，还没有把controlboard进行拆分
2. 修复Debug信息接收概率失败的bug，统一使用 Qt 原生的readyRead
3. 软件开启后默认全屏
4. 修复字号错误的bug
5. 软件现在正常工作，Client各部分运行正常，Core可以正常运行各个Test脚本，Python的scan_tool可以正常工作
6. Python的scan_tool现在可以扫描ZBin/lua_script/play/下的lua文件
7. 为qml的import限定版本号
8. 为Core链接YAML_CPP，修复Core的编译错误
9. 修复KILL按钮无法KILL的问题
10. 修复Instance失效的问题
11. 重写Setting界面UI，因为TreeView只在Qt5可用
12. 重新链接球速显示窗的needDraw等信号
13. 为share/zos下的部分文件增加检查，防止程序的偶发崩溃